### PR TITLE
chore: exclude blog from TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "jsxImportSource": "preact"
   },
   "include": ["**/*.ts", "**/*.tsx", "./package.json"],
-  "exclude": ["build/**/*.d.ts"]
+  "exclude": ["build/**/*.d.ts", "content/Blog/**"]
 }


### PR DESCRIPTION
## Summary
- exclude the blog directory from TypeScript project config

## Testing
- `npm run check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bdee41553883279cc4212d0d85a37c