### PR TITLE
Polish mobile layout and Giscus accent

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -25,6 +25,8 @@ export const defaultContentPageLayout: PageLayout = {
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({
+      wrap: "wrap",
+      gap: "0.75rem",
       components: [
         {
           Component: Component.Search(),
@@ -50,6 +52,8 @@ export const defaultListPageLayout: PageLayout = {
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({
+      wrap: "wrap",
+      gap: "0.75rem",
       components: [
         {
           Component: Component.Search(),

--- a/quartz/components/Comments.tsx
+++ b/quartz/components/Comments.tsx
@@ -3,7 +3,7 @@ import { classNames } from "../util/lang"
 // @ts-ignore
 import script from "./scripts/comments.inline"
 
-const Comments: QuartzComponent = ({ displayClass, fileData }: QuartzComponentProps) => {
+const Comments: QuartzComponent = ({ displayClass, fileData, cfg }: QuartzComponentProps) => {
   // Allow per-page opt-out via frontmatter
   const disableComment: boolean =
     typeof fileData.frontmatter?.comments !== "undefined" &&
@@ -12,6 +12,21 @@ const Comments: QuartzComponent = ({ displayClass, fileData }: QuartzComponentPr
   if (disableComment) {
     return <></>
   }
+
+  const themeUrl = (() => {
+    if (!cfg.baseUrl) {
+      return "https://giscus.app/themes"
+    }
+
+    const withProtocol = cfg.baseUrl.startsWith("http") ? cfg.baseUrl : `https://${cfg.baseUrl}`
+    try {
+      const normalizedBase = withProtocol.endsWith("/") ? withProtocol : `${withProtocol}/`
+      const resolved = new URL("./static/giscus", normalizedBase)
+      return resolved.toString().replace(/\/+$/, "")
+    } catch {
+      return `${withProtocol.replace(/\/+$/, "")}/static/giscus`
+    }
+  })()
 
   return (
     <section
@@ -24,7 +39,7 @@ const Comments: QuartzComponent = ({ displayClass, fileData }: QuartzComponentPr
       data-strict="0"
       data-reactions-enabled="1"
       data-input-position="bottom"
-      data-theme-url="https://giscus.app/themes"
+      data-theme-url={themeUrl}
       data-light-theme="light"
       data-dark-theme="dark"
       data-lang="en"

--- a/quartz/components/Footer.tsx
+++ b/quartz/components/Footer.tsx
@@ -1,15 +1,8 @@
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 import style from "./styles/footer.scss"
-import { version } from "../../package.json"
-import { i18n } from "../i18n"
 
-interface Options {
-  links: Record<string, string>
-}
-
-export default ((opts?: Options) => {
-  const Footer: QuartzComponent = ({ displayClass, cfg }: QuartzComponentProps) => {
-    // Return empty footer with no content
+export default (() => {
+  const Footer: QuartzComponent = ({ displayClass }: QuartzComponentProps) => {
     return <footer class={`${displayClass ?? ""}`}></footer>
   }
 

--- a/quartz/components/scripts/comments.inline.ts
+++ b/quartz/components/scripts/comments.inline.ts
@@ -1,19 +1,22 @@
 const changeTheme = (e: CustomEventMap["themechange"]) => {
   const theme = e.detail.theme
-  const iframe = document.querySelector("iframe.giscus-frame") as HTMLIFrameElement
-  if (!iframe) {
+  const iframe = document.querySelector("iframe.giscus-frame") as HTMLIFrameElement | null
+  if (!iframe || !iframe.contentWindow) {
     return
   }
 
-  if (!iframe.contentWindow) {
-    return
+  const themeName = getThemeName(theme)
+  const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
+  if (giscusContainer) {
+    giscusContainer.dataset.theme = themeName
+    giscusContainer.setAttribute("data-theme", themeName)
   }
 
   iframe.contentWindow.postMessage(
     {
       giscus: {
         setConfig: {
-          theme: getThemeUrl(getThemeName(theme)),
+          theme: getThemeUrl(themeName),
         },
       },
     },
@@ -25,7 +28,7 @@ const getThemeName = (theme: string) => {
   if (theme !== "dark" && theme !== "light") {
     return theme
   }
-  const giscusContainer = document.querySelector(".giscus") as GiscusElement
+  const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
   if (!giscusContainer) {
     return theme
   }
@@ -35,7 +38,7 @@ const getThemeName = (theme: string) => {
 }
 
 const getThemeUrl = (theme: string) => {
-  const giscusContainer = document.querySelector(".giscus") as GiscusElement
+  const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
   if (!giscusContainer) {
     return `https://giscus.app/themes/${theme}.css`
   }
@@ -51,6 +54,7 @@ type GiscusElement = Omit<HTMLElement, "dataset"> & {
     themeUrl: string
     lightTheme: string
     darkTheme: string
+    theme?: string
     mapping: "url" | "title" | "og:title" | "specific" | "number" | "pathname"
     strict: string
     reactionsEnabled: string
@@ -60,7 +64,7 @@ type GiscusElement = Omit<HTMLElement, "dataset"> & {
 }
 
 document.addEventListener("nav", () => {
-  const giscusContainer = document.querySelector(".giscus") as GiscusElement
+  const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
   if (!giscusContainer) {
     return
   }
@@ -91,8 +95,10 @@ document.addEventListener("nav", () => {
         : prefersLight
           ? "light"
           : "dark"
-  giscusContainer.setAttribute("data-theme", theme)
-  giscusScript.setAttribute("data-theme", getThemeUrl(getThemeName(theme)))
+  const themeName = getThemeName(theme)
+  giscusContainer.dataset.theme = themeName
+  giscusContainer.setAttribute("data-theme", themeName)
+  giscusScript.setAttribute("data-theme", getThemeUrl(themeName))
 
   giscusContainer.appendChild(giscusScript)
 

--- a/quartz/components/scripts/comments.inline.ts
+++ b/quartz/components/scripts/comments.inline.ts
@@ -81,8 +81,16 @@ document.addEventListener("nav", () => {
   giscusScript.setAttribute("data-input-position", giscusContainer.dataset.inputPosition)
   giscusScript.setAttribute("data-lang", giscusContainer.dataset.lang)
   const storedTheme = localStorage.getItem("theme")
+  const savedTheme = document.documentElement.getAttribute("saved-theme")
   const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches
-  const theme = storedTheme ?? (prefersLight ? "light" : "dark")
+  const theme =
+    savedTheme === "light" || savedTheme === "dark"
+      ? savedTheme
+      : storedTheme === "light" || storedTheme === "dark"
+        ? storedTheme
+        : prefersLight
+          ? "light"
+          : "dark"
   giscusContainer.setAttribute("data-theme", theme)
   giscusScript.setAttribute("data-theme", getThemeUrl(getThemeName(theme)))
 

--- a/quartz/static/giscus/dark.css
+++ b/quartz/static/giscus/dark.css
@@ -45,16 +45,16 @@ main {
   --color-btn-active-border: #cfcfcf;
   --color-btn-selected-bg: #2d2d2d; /* --lightgray */
   --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #cc4e00; /* orange accent */
+  --color-btn-primary-bg: #ffa726; /* quartz tertiary */
   --color-btn-primary-border: rgb(255 255 255 / 10%); /* --dark */
   --color-btn-primary-shadow: 0 0 transparent;
   --color-btn-primary-inset-shadow: 0 0 transparent;
-  --color-btn-primary-hover-bg: #a63c00;
+  --color-btn-primary-hover-bg: #e5941f;
   --color-btn-primary-hover-border: rgb(255 255 255 / 10%); /* --dark */
-  --color-btn-primary-selected-bg: #a63c00;
+  --color-btn-primary-selected-bg: #e5941f;
   --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 25%);
   --color-btn-primary-disabled-text: rgba(255, 255, 255, 0.5);
-  --color-btn-primary-disabled-bg: rgba(204, 78, 0, 0.35);
+  --color-btn-primary-disabled-bg: rgba(255, 167, 38, 0.3);
   --color-btn-primary-disabled-border: rgb(255 255 255 / 10%);
   --color-action-list-item-default-hover-bg: rgb(64 64 64 / 40%);
   --color-segmented-control-bg: rgb(64 64 64 / 40%);
@@ -75,9 +75,9 @@ main {
   --color-accent-muted: rgb(255 107 107 / 40%);
   --color-accent-subtle: rgba(255, 107, 107, 0.15);
   --color-success-fg: #3fb950;
-  --color-attention-fg: #cc4e00;
-  --color-attention-muted: rgb(204 78 0 / 40%);
-  --color-attention-subtle: rgba(204, 78, 0, 0.2);
+  --color-attention-fg: #ffa726;
+  --color-attention-muted: rgb(255 167 38 / 35%);
+  --color-attention-subtle: rgba(255, 167, 38, 0.22);
   --color-danger-fg: #ff6b6b; /* --secondary */
   --color-danger-muted: rgb(255 107 107 / 40%);
   --color-danger-subtle: rgba(255, 107, 107, 0.15);

--- a/quartz/static/giscus/dark.css
+++ b/quartz/static/giscus/dark.css
@@ -34,56 +34,56 @@ main {
   --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
   --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-  --color-btn-text: #d4d4d4; /* --darkgray */
-  --color-btn-bg: #161618; /* --light */
-  --color-btn-border: rgb(240, 246, 252 / 10%); /* --dark */
+  --color-btn-text: #e0e0e0; /* --darkgray */
+  --color-btn-bg: #1a1a1a; /* --light */
+  --color-btn-border: rgb(255 255 255 / 10%); /* --dark */
   --color-btn-shadow: 0 0 transparent;
   --color-btn-inset-shadow: 0 0 transparent;
-  --color-btn-hover-bg: #30363d;
-  --color-btn-hover-border: #8b949e;
-  --color-btn-active-bg: hsl(212deg 12% 18% / 100%);
-  --color-btn-active-border: #6e7681;
-  --color-btn-selected-bg: #161b22;
+  --color-btn-hover-bg: #2d2d2d; /* --lightgray */
+  --color-btn-hover-border: #e0e0e0; /* --darkgray */
+  --color-btn-active-bg: #262626;
+  --color-btn-active-border: #cfcfcf;
+  --color-btn-selected-bg: #2d2d2d; /* --lightgray */
   --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #84a59d; /* --tertiary */
-  --color-btn-primary-border: rgb(240, 246, 252 / 10%); /* --dark */
+  --color-btn-primary-bg: #cc4e00; /* orange accent */
+  --color-btn-primary-border: rgb(255 255 255 / 10%); /* --dark */
   --color-btn-primary-shadow: 0 0 transparent;
   --color-btn-primary-inset-shadow: 0 0 transparent;
-  --color-btn-primary-hover-bg: #7b97aa; /* --secondary */
-  --color-btn-primary-hover-border: rgb(240, 246, 252 / 10%); /* --dark */
-  --color-btn-primary-selected-bg: #7b97aa; /* --secondary */
-  --color-btn-primary-selected-shadow: 0 0 transparent;
-  --color-btn-primary-disabled-text: rgba(33, 32, 32, 0.5);
-  --color-btn-primary-disabled-bg: rgb(35 134 54 / 60%);
-  --color-btn-primary-disabled-border: rgb(240 246 252 / 10%);
-  --color-action-list-item-default-hover-bg: rgb(177 186 196 / 12%);
-  --color-segmented-control-bg: rgb(110 118 129 / 10%);
-  --color-segmented-control-button-bg: #0d1117;
-  --color-segmented-control-button-selected-border: #6e7681;
-  --color-fg-default: #ebebec; /* --dark */
-  --color-fg-muted: #d4d4d4; /* --darkgray */
-  --color-fg-subtle: #d4d4d4; /* --darkgray */
-  --color-canvas-default: #0d1117;
-  --color-canvas-overlay: #161b22;
-  --color-canvas-inset: #010409;
-  --color-canvas-subtle: #161b22;
-  --color-border-default: #30363d;
-  --color-border-muted: #21262d;
-  --color-neutral-muted: rgb(110 118 129 / 40%);
-  --color-accent-fg: #2f81f7;
-  --color-accent-emphasis: #1f6feb;
-  --color-accent-muted: rgb(56 139 253 / 40%);
-  --color-accent-subtle: rgb(56 139 253 / 10%);
+  --color-btn-primary-hover-bg: #a63c00;
+  --color-btn-primary-hover-border: rgb(255 255 255 / 10%); /* --dark */
+  --color-btn-primary-selected-bg: #a63c00;
+  --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 25%);
+  --color-btn-primary-disabled-text: rgba(255, 255, 255, 0.5);
+  --color-btn-primary-disabled-bg: rgba(204, 78, 0, 0.35);
+  --color-btn-primary-disabled-border: rgb(255 255 255 / 10%);
+  --color-action-list-item-default-hover-bg: rgb(64 64 64 / 40%);
+  --color-segmented-control-bg: rgb(64 64 64 / 40%);
+  --color-segmented-control-button-bg: #1a1a1a;
+  --color-segmented-control-button-selected-border: #e0e0e0;
+  --color-fg-default: #ffffff; /* --dark */
+  --color-fg-muted: #e0e0e0; /* --darkgray */
+  --color-fg-subtle: #e0e0e0; /* --darkgray */
+  --color-canvas-default: #1a1a1a; /* --light */
+  --color-canvas-overlay: #2d2d2d; /* --lightgray */
+  --color-canvas-inset: #121212;
+  --color-canvas-subtle: #2d2d2d; /* --lightgray */
+  --color-border-default: #404040; /* --gray */
+  --color-border-muted: #2d2d2d; /* --lightgray */
+  --color-neutral-muted: rgb(224 224 224 / 16%);
+  --color-accent-fg: #ff6b6b; /* --secondary */
+  --color-accent-emphasis: #ff6b6b; /* --secondary */
+  --color-accent-muted: rgb(255 107 107 / 40%);
+  --color-accent-subtle: rgba(255, 107, 107, 0.15);
   --color-success-fg: #3fb950;
-  --color-attention-fg: #d29922;
-  --color-attention-muted: rgb(187 128 9 / 40%);
-  --color-attention-subtle: rgb(187 128 9 / 15%);
-  --color-danger-fg: #f85149;
-  --color-danger-muted: rgb(248 81 73 / 40%);
-  --color-danger-subtle: rgb(248 81 73 / 10%);
+  --color-attention-fg: #cc4e00;
+  --color-attention-muted: rgb(204 78 0 / 40%);
+  --color-attention-subtle: rgba(204, 78, 0, 0.2);
+  --color-danger-fg: #ff6b6b; /* --secondary */
+  --color-danger-muted: rgb(255 107 107 / 40%);
+  --color-danger-subtle: rgba(255, 107, 107, 0.15);
   --color-primer-shadow-inset: 0 0 transparent;
-  --color-scale-gray-7: #21262d;
-  --color-scale-blue-8: #0c2d6b;
+  --color-scale-gray-7: #2d2d2d;
+  --color-scale-blue-8: #4a1f17;
 
   /*! Extensions from @primer/css/alerts/flash.scss */
   --color-social-reaction-bg-hover: var(--color-scale-gray-7);

--- a/quartz/static/giscus/light.css
+++ b/quartz/static/giscus/light.css
@@ -34,56 +34,56 @@ main {
   --color-prettylights-syntax-brackethighlighter-angle: #57606a;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #8c959f;
   --color-prettylights-syntax-constant-other-reference-link: #0a3069;
-  --color-btn-text: #4e4e4e; /* --darkgray */
-  --color-btn-bg: #faf8f8; /* --light */
-  --color-btn-border: rgb(43, 43, 43 / 15%); /* --dark */
-  --color-btn-shadow: 0 1px 0 rgb(31 35 40 / 4%);
+  --color-btn-text: #666666; /* --darkgray */
+  --color-btn-bg: #ffffff; /* --light */
+  --color-btn-border: rgb(51 51 51 / 15%); /* --dark */
+  --color-btn-shadow: 0 1px 0 rgb(51 51 51 / 4%);
   --color-btn-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 25%);
-  --color-btn-hover-bg: #f3f4f6;
-  --color-btn-hover-border: rgb(43, 43, 43 / 15%); /* --dark */
-  --color-btn-active-bg: hsl(220deg 14% 93% / 100%);
-  --color-btn-active-border: rgb(31 35 40 / 15%);
-  --color-btn-selected-bg: hsl(220deg 14% 94% / 100%);
+  --color-btn-hover-bg: #f5f5f5; /* --lightgray */
+  --color-btn-hover-border: rgb(51 51 51 / 15%); /* --dark */
+  --color-btn-active-bg: #f0f0f0;
+  --color-btn-active-border: rgb(51 51 51 / 15%);
+  --color-btn-selected-bg: #f5f5f5; /* --lightgray */
   --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #84a59d; /* --tertiary */
-  --color-btn-primary-border: rgb(43, 43, 43 / 15%); /* --dark */
-  --color-btn-primary-shadow: 0 1px 0 rgb(31 35 40 / 10%);
-  --color-btn-primary-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 3%);
-  --color-btn-primary-hover-bg: #284b63; /* --secondary */
-  --color-btn-primary-hover-border: rgb(43, 43, 43 / 15%); /* --dark */
-  --color-btn-primary-selected-bg: #284b63; /* --secondary */
-  --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 45 17 / 20%);
+  --color-btn-primary-bg: #cc4e00; /* orange accent */
+  --color-btn-primary-border: rgb(51 51 51 / 15%); /* --dark */
+  --color-btn-primary-shadow: 0 1px 0 rgb(51 51 51 / 10%);
+  --color-btn-primary-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 6%);
+  --color-btn-primary-hover-bg: #a63c00;
+  --color-btn-primary-hover-border: rgb(51 51 51 / 15%); /* --dark */
+  --color-btn-primary-selected-bg: #a63c00;
+  --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 12%);
   --color-btn-primary-disabled-text: rgb(255 255 255 / 80%);
-  --color-btn-primary-disabled-bg: #94d3a2;
-  --color-btn-primary-disabled-border: rgb(31 35 40 / 15%);
+  --color-btn-primary-disabled-bg: rgba(204, 78, 0, 0.45);
+  --color-btn-primary-disabled-border: rgb(51 51 51 / 15%);
   --color-action-list-item-default-hover-bg: rgb(208 215 222 / 32%);
-  --color-segmented-control-bg: #eaeef2;
+  --color-segmented-control-bg: #f5f5f5;
   --color-segmented-control-button-bg: #fff;
-  --color-segmented-control-button-selected-border: #8c959f;
-  --color-fg-default: #2b2b2b; /* --dark */
-  --color-fg-muted: #4e4e4e; /* --darkgray */
-  --color-fg-subtle: #4e4e4e; /* --darkgray */
-  --color-canvas-default: #fff;
-  --color-canvas-overlay: #fff;
-  --color-canvas-inset: #f6f8fa;
-  --color-canvas-subtle: #f6f8fa;
-  --color-border-default: #d0d7de;
-  --color-border-muted: hsl(210deg 18% 87% / 100%);
-  --color-neutral-muted: rgb(175 184 193 / 20%);
-  --color-accent-fg: #0969da;
-  --color-accent-emphasis: #0969da;
-  --color-accent-muted: rgb(84 174 255 / 40%);
-  --color-accent-subtle: #ddf4ff;
+  --color-segmented-control-button-selected-border: #d0d0d0;
+  --color-fg-default: #333333; /* --dark */
+  --color-fg-muted: #666666; /* --darkgray */
+  --color-fg-subtle: #666666; /* --darkgray */
+  --color-canvas-default: #ffffff; /* --light */
+  --color-canvas-overlay: #ffffff;
+  --color-canvas-inset: #f5f5f5; /* --lightgray */
+  --color-canvas-subtle: #f5f5f5; /* --lightgray */
+  --color-border-default: #d0d0d0; /* --gray */
+  --color-border-muted: #e6e6e6;
+  --color-neutral-muted: rgb(102 102 102 / 20%);
+  --color-accent-fg: #ff6b6b; /* --secondary */
+  --color-accent-emphasis: #ff6b6b; /* --secondary */
+  --color-accent-muted: rgb(255 107 107 / 40%);
+  --color-accent-subtle: rgba(255, 107, 107, 0.15);
   --color-success-fg: #1a7f37;
-  --color-attention-fg: #9a6700;
-  --color-attention-muted: rgb(212 167 44 / 40%);
-  --color-attention-subtle: #fff8c5;
-  --color-danger-fg: #d1242f;
-  --color-danger-muted: rgb(255 129 130 / 40%);
-  --color-danger-subtle: #ffebe9;
+  --color-attention-fg: #cc4e00;
+  --color-attention-muted: rgb(204 78 0 / 40%);
+  --color-attention-subtle: rgba(204, 78, 0, 0.18);
+  --color-danger-fg: #ff6b6b; /* --secondary */
+  --color-danger-muted: rgb(255 107 107 / 40%);
+  --color-danger-subtle: rgba(255, 107, 107, 0.15);
   --color-primer-shadow-inset: inset 0 1px 0 rgb(208 215 222 / 20%);
-  --color-scale-gray-1: #eaeef2;
-  --color-scale-blue-1: #b6e3ff;
+  --color-scale-gray-1: #f5f5f5;
+  --color-scale-blue-1: #fff3cd; /* --textHighlight */
 
   /*! Extensions from @primer/css/alerts/flash.scss */
   --color-social-reaction-bg-hover: var(--color-scale-gray-1);

--- a/quartz/static/giscus/light.css
+++ b/quartz/static/giscus/light.css
@@ -45,16 +45,16 @@ main {
   --color-btn-active-border: rgb(51 51 51 / 15%);
   --color-btn-selected-bg: #f5f5f5; /* --lightgray */
   --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #cc4e00; /* orange accent */
+  --color-btn-primary-bg: #ffa726; /* quartz tertiary */
   --color-btn-primary-border: rgb(51 51 51 / 15%); /* --dark */
   --color-btn-primary-shadow: 0 1px 0 rgb(51 51 51 / 10%);
   --color-btn-primary-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 6%);
-  --color-btn-primary-hover-bg: #a63c00;
+  --color-btn-primary-hover-bg: #e5941f;
   --color-btn-primary-hover-border: rgb(51 51 51 / 15%); /* --dark */
-  --color-btn-primary-selected-bg: #a63c00;
+  --color-btn-primary-selected-bg: #e5941f;
   --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 12%);
   --color-btn-primary-disabled-text: rgb(255 255 255 / 80%);
-  --color-btn-primary-disabled-bg: rgba(204, 78, 0, 0.45);
+  --color-btn-primary-disabled-bg: rgba(255, 167, 38, 0.45);
   --color-btn-primary-disabled-border: rgb(51 51 51 / 15%);
   --color-action-list-item-default-hover-bg: rgb(208 215 222 / 32%);
   --color-segmented-control-bg: #f5f5f5;
@@ -75,9 +75,9 @@ main {
   --color-accent-muted: rgb(255 107 107 / 40%);
   --color-accent-subtle: rgba(255, 107, 107, 0.15);
   --color-success-fg: #1a7f37;
-  --color-attention-fg: #cc4e00;
-  --color-attention-muted: rgb(204 78 0 / 40%);
-  --color-attention-subtle: rgba(204, 78, 0, 0.18);
+  --color-attention-fg: #ffa726;
+  --color-attention-muted: rgb(255 167 38 / 40%);
+  --color-attention-subtle: rgba(255, 167, 38, 0.18);
   --color-danger-fg: #ff6b6b; /* --secondary */
   --color-danger-muted: rgb(255 107 107 / 40%);
   --color-danger-subtle: rgba(255, 107, 107, 0.15);

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,3 +1,79 @@
 @use "./base.scss";
+@use "./variables.scss" as *;
 
-// put your custom CSS here!
+// Responsive polish for narrower viewports
+@media all and ($mobile) {
+  .page > #quartz-body {
+    padding-inline: clamp(0.5rem, 3.5vw, 0.85rem);
+    row-gap: clamp(1.25rem, 6vw, 2.25rem);
+  }
+
+  header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: clamp(0.75rem, 4vw, 1.25rem);
+    margin: clamp(1.25rem, 5vw, 1.75rem) 0;
+  }
+
+  header > * {
+    width: 100%;
+  }
+
+  .page > #quartz-body .sidebar.left {
+    width: 100%;
+    flex-wrap: wrap;
+    gap: clamp(0.75rem, 4vw, 1.25rem);
+    justify-content: center;
+    padding-top: clamp(1rem, 4vw, 1.5rem);
+  }
+
+  .page > #quartz-body .sidebar.left > .spacer {
+    display: none;
+  }
+
+  .page > #quartz-body .sidebar.left > *:not(.spacer) {
+    flex: 1 1 min(16rem, 100%);
+  }
+
+  .page > #quartz-body .sidebar.left > h2.page-title {
+    text-align: center;
+  }
+
+  .page > #quartz-body .sidebar.left > .flex-component {
+    gap: clamp(0.5rem, 4vw, 1rem);
+  }
+
+  .page > #quartz-body .sidebar.left > .flex-component > div:first-child {
+    flex-basis: 100%;
+  }
+
+  .page > #quartz-body .sidebar.left > .flex-component > div {
+    flex: 1 1 45%;
+  }
+
+  .page > #quartz-body .sidebar.left .search {
+    max-width: none;
+    width: 100%;
+  }
+
+  .page > #quartz-body .center > article {
+    padding-inline: clamp(0.25rem, 3vw, 0.75rem);
+  }
+
+  footer {
+    text-align: center;
+    margin-bottom: clamp(3rem, 8vw, 4rem);
+  }
+
+  footer ul {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: clamp(0.5rem, 3vw, 1rem);
+  }
+}
+
+@media all and (max-width: 480px) {
+  .page > #quartz-body .sidebar.left > .flex-component > div {
+    flex-basis: 100%;
+  }
+}

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,6 +1,55 @@
 @use "./base.scss";
 @use "./variables.scss" as *;
 
+// Layout refinements shared across viewports
+.page > #quartz-body .center {
+  min-width: 0;
+}
+
+.page > #quartz-body .center > article {
+  width: min(100%, 72ch);
+  margin-inline: auto;
+}
+
+.giscus {
+  width: min(100%, 72ch);
+  margin: clamp(2.5rem, 7vw, 3.5rem) auto 0;
+  padding: clamp(1.5rem, 5vw, 2rem) clamp(1.25rem, 5vw, 2.25rem);
+  border-radius: 1rem;
+  border: 1px solid color-mix(in srgb, var(--gray) 42%, transparent);
+  background: color-mix(in srgb, var(--light) 92%, transparent);
+  box-shadow: 0 22px 50px -32px color-mix(in srgb, var(--dark) 18%, transparent);
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+:root[saved-theme="dark"] .giscus {
+  border-color: color-mix(in srgb, var(--gray) 55%, transparent);
+  background: color-mix(in srgb, var(--light) 75%, rgba(255, 255, 255, 0.04));
+  box-shadow: 0 22px 50px -34px color-mix(in srgb, var(--dark) 45%, transparent);
+}
+
+.giscus iframe {
+  width: 100% !important;
+}
+
+@media all and ($tablet) {
+  .page > #quartz-body {
+    padding-inline: clamp(1rem, 4vw, 2rem);
+    row-gap: clamp(1.5rem, 5vw, 2.5rem);
+  }
+
+  .page > #quartz-body .center > article {
+    padding-inline: clamp(0.75rem, 3vw, 1.5rem);
+  }
+
+  .giscus {
+    margin-top: clamp(2rem, 6vw, 3rem);
+  }
+}
+
 // Responsive polish for narrower viewports
 @media all and ($mobile) {
   .page > #quartz-body {
@@ -58,6 +107,11 @@
 
   .page > #quartz-body .center > article {
     padding-inline: clamp(0.25rem, 3vw, 0.75rem);
+  }
+
+  .giscus {
+    margin-top: clamp(2rem, 8vw, 3rem);
+    padding: clamp(1.25rem, 6vw, 1.75rem) clamp(1rem, 6vw, 1.5rem);
   }
 
   footer {


### PR DESCRIPTION
## Summary
- allow the sidebar utility controls to wrap with consistent spacing so they don’t crowd on smaller screens
- layer responsive SCSS overrides that widen the reading column, tidy sidebar layouts, and center the footer on phones
- recolor the Giscus button and attention tokens to an accessible Quartz-inspired orange in both light and dark themes

## Testing
- npx quartz build
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d050eab5f883279919f7f05d6e17e3