### PR TITLE
Apply Gruvbox theme to Quartz site

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,303 +1,2012 @@
+@use "sass:color";
+@use "sass:list";
+@use "sass:map";
+@use "sass:meta";
+@use "sass:string";
 @use "./base.scss";
+@use "./variables.scss" as *;
 
-// Gruvbox Text Colors Only
-// =========================
+:root[saved-theme="dark"],
+html[saved-theme="dark"] {
+  body {
+    color-scheme: dark;
 
-// Heading colors from Gruvbox
-h1,
-.page-title,
-.article-title,
-header h1,
-.page article h1 {
-  color: #cc241d !important; /* Gruvbox red */
+    .callout {
+      --callout-blend-mode: lighten;
+    }
+
+    code[data-theme*=" "] {
+      color: var(--shiki-dark);
+      background-color: var(--shiki-dark-bg);
+    }
+
+    code[data-theme*=" "] span {
+      color: var(--shiki-dark);
+    }
+
+    --accent-h: 12;
+    --accent-s: 107%;
+    --accent-l: 32%;
+
+    color-scheme: dark;
+    --mono-rgb-100: 255, 255, 255;
+    --color-base-00: #1e1e1e;
+    --color-base-10: #242424;
+    --color-base-20: #262626;
+    --color-base-25: #2a2a2a;
+    --color-base-30: #363636;
+    --color-base-35: #3f3f3f;
+    --color-base-40: #555555;
+    --color-base-50: #666666;
+    --color-base-70: #b3b3b3;
+    --color-base-100: #dadada;
+    --color-accent-hsl: var(--accent-h), var(--accent-s), var(--accent-l);
+    --color-accent: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
+    --color-accent-1: hsl(
+      calc(var(--accent-h) - 3),
+      calc(var(--accent-s) * 1.02),
+      calc(var(--accent-l) * 1.15)
+    );
+    --color-accent-2: hsl(
+      calc(var(--accent-h) - 5),
+      calc(var(--accent-s) * 1.05),
+      calc(var(--accent-l) * 1.29)
+    );
+    --background-modifier-form-field: var(--color-base-25);
+    --interactive-accent: var(--color-accent);
+    --interactive-accent-hover: var(--color-accent-1);
+    --shadow-s: 0px 1px 2px #000000, 0px 3.4px 6.7px #000000, 0px 15px 30px #000000;
+    --shadow-l: 0px 1.8px 7.3px #000000, 0px 6.3px 24.7px #000000, 0px 30px 90px #000000;
+    --color-red: var(--neutral-red);
+    --color-purple: var(--neutral-purple);
+    --color-green: var(--neutral-green);
+    --color-cyan: var(--neutral-blue);
+    --color-blue: var(--faded-blue);
+    --color-yellow: var(--neutral-yellow);
+    --color-orange: var(--neutral-orange);
+    --color-pink: var(--bright-purple);
+    --background-primary: var(--dark0);
+    --background-primary-alt: var(--dark0);
+    --background-secondary: var(--dark0-hard);
+    --background-modifier-border: var(--dark1);
+    --text-normal: var(--light0);
+    --text-faint: var(--light1);
+    --text-muted: var(--light2);
+    --h1-color: var(--neutral-red);
+    --h2-color: var(--neutral-yellow);
+    --h3-color: var(--neutral-green);
+    --h4-color: var(--neutral-aqua);
+    --h5-color: var(--neutral-blue);
+    --h6-color: var(--neutral-purple);
+    --text-highlight-bg: var(--neutral-yellow);
+    --text-accent: var(--neutral-orange);
+    --text-accent-hover: var(--bright-aqua);
+    --tag-color: var(--bright-aqua);
+    --tag-background: var(--dark2);
+    --tag-background-hover: var(--dark1);
+    --inline-title-color: var(--bright-yellow);
+    --bold-color: var(--neutral-yellow);
+    --italic-color: var(--neutral-yellow);
+    --checkbox-color: var(--light4);
+    --checkbox-color-hover: var(--light4);
+    --checkbox-border-color: var(--light4);
+    --checkbox-border-color-hover: var(--light4);
+    --code-normal: var(--bright-blue);
+    --code-background: var(--dark1);
+    --nav-item-color-active: var(--bright-aqua);
+    --graph-line: var(--dark2);
+    --graph-node-tag: var(--neutral-red);
+    --highlight-mix-blend-mode: darken;
+  }
 }
 
-h2,
-header h2,
-.page article h2 {
-  color: #98971a !important; /* Gruvbox green */
+:root[saved-theme="light"],
+html[saved-theme="light"] {
+  body {
+    color-scheme: light;
+
+    .callout {
+      --callout-blend-mode: darken;
+    }
+
+    code[data-theme*=" "] {
+      color: var(--shiki-light);
+      background-color: var(--shiki-light-bg);
+    }
+
+    code[data-theme*=" "] span {
+      color: var(--shiki-light);
+    }
+
+    --accent-h: 12;
+    --accent-s: 107%;
+    --accent-l: 32%;
+
+    color-scheme: light;
+    --highlight-mix-blend-mode: darken;
+    --mono-rgb-100: 0, 0, 0;
+    --color-base-00: #ffffff;
+    --color-base-10: #fafafa;
+    --color-base-20: #f6f6f6;
+    --color-base-25: #e3e3e3;
+    --color-base-30: #e0e0e0;
+    --color-base-35: #d4d4d4;
+    --color-base-40: #bdbdbd;
+    --color-base-50: #ababab;
+    --color-base-70: #5c5c5c;
+    --color-base-100: #222222;
+    --color-accent-hsl: var(--accent-h), var(--accent-s), var(--accent-l);
+    --color-accent: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
+    --color-accent-1: hsl(
+      calc(var(--accent-h) - 1),
+      calc(var(--accent-s) * 1.01),
+      calc(var(--accent-l) * 1.075)
+    );
+    --color-accent-2: hsl(
+      calc(var(--accent-h) - 3),
+      calc(var(--accent-s) * 1.02),
+      calc(var(--accent-l) * 1.15)
+    );
+    --shadow-s: 0px 1px 2px #000000, 0px 3.4px 6.7px #000000, 0px 15px 30px #000000;
+    --shadow-l: 0px 1.8px 7.3px #000000, 0px 6.3px 24.7px #000000, 0px 30px 90px #000000;
+    --color-red: var(--neutral-red);
+    --color-purple: var(--neutral-purple);
+    --color-green: var(--neutral-green);
+    --color-cyan: var(--neutral-blue);
+    --color-blue: var(--faded-blue);
+    --color-yellow: var(--neutral-yellow);
+    --color-orange: var(--neutral-orange);
+    --color-pink: var(--bright-purple);
+    --background-primary: var(--light0-hard);
+    --background-primary-alt: var(--light0-hard);
+    --background-secondary: var(--light1);
+    --background-modifier-border: var(--light2);
+    --text-normal: var(--dark0);
+    --text-faint: var(--dark3);
+    --text-muted: var(--dark2);
+    --h1-color: var(--neutral-red);
+    --h2-color: var(--neutral-yellow);
+    --h3-color: var(--neutral-green);
+    --h4-color: var(--neutral-aqua);
+    --h5-color: var(--neutral-blue);
+    --h6-color: var(--neutral-purple);
+    --text-highlight-bg: var(--bright-yellow);
+    --text-accent: var(--neutral-orange);
+    --text-accent-hover: var(--bright-aqua);
+    --tag-color: var(--neutral-aqua);
+    --tag-background: var(--light1);
+    --tag-background-hover: rgba(var(--light1_x), 0.6);
+    --inline-title-color: var(--bright-yellow);
+    --bold-color: var(--neutral-yellow);
+    --italic-color: var(--neutral-yellow);
+    --checkbox-color: var(--light4);
+    --checkbox-color-hover: var(--light4);
+    --checkbox-border-color: var(--light4);
+    --checkbox-border-color-hover: var(--light4);
+    --code-normal: var(--bright-blue);
+    --code-background: var(--light1);
+    --nav-item-color-active: var(--neutral-blue);
+    --graph-line: var(--light1);
+    --graph-node-tag: var(--neutral-red);
+  }
 }
 
-h3,
-header h3,
-.page article h3 {
-  color: #d79921 !important; /* Gruvbox yellow */
+@font-face {
+  font-family: "Avenir";
+  font-style: normal;
+  font-weight: 400;
+  src:
+    local("Avenir"),
+    url("https://fonts.cdnfonts.com/s/71748/avenir_roman_12.woff") format("woff");
 }
 
-h4,
-.page article h4 {
-  color: #458588 !important; /* Gruvbox aqua */
+/* cyrillic-ext */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZJhiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZthiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZNhiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZxhiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZBhiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range:
+    U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+    U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZFhiJ-Ek-_EeAmM.woff2)
+    format("woff2");
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/inter/v18/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfAZ9hiJ-Ek-_EeA.woff2)
+    format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-h5,
-.page article h5 {
-  color: #b16286 !important; /* Gruvbox purple */
+/* cyrillic-ext */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMRrTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range: U+0460-052F, U+1C80-1C8A, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtM1rTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMVrTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMprTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMZrTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range:
+    U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301,
+    U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMdrTFcZZJmOpwVS.woff2)
+    format("woff2");
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: "Source Code Pro";
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/s/sourcecodepro/v23/HI_diYsKILxRpg3hIP6sJ7fM7PqPMcMnZFqUwX28DMyQtMlrTFcZZJmOpw.woff2)
+    format("woff2");
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
-h6,
-.page article h6 {
-  color: #689d6a !important; /* Gruvbox aqua */
-}
-
-// Gruvbox text emphasis and styling - only for regular content, not callouts
-.page article strong:not(.callout strong),
-.page article p > strong:not(.callout strong) {
-  color: #d79921 !important; /* Gruvbox yellow */
-  font-weight: 600 !important;
-}
-
-.page article em:not(.callout em),
-.page article i:not(.callout i),
-.page article p > em:not(.callout em),
-.page article p > i:not(.callout i) {
-  color: #d79921 !important; /* Gruvbox yellow */
-  font-style: italic !important;
-}
-
-// Links with Gruvbox colors
-a,
-a.internal,
-a.external,
-.page article a {
-  color: #cc241d !important; /* Gruvbox red */
-  text-decoration: none !important;
-}
-
-a:hover,
-a.internal:hover,
-a.external:hover {
-  color: #98971a !important; /* Gruvbox green */
-}
-
-// Code styling with Gruvbox - only for regular content, not callouts
-.page article code:not(pre code):not(.callout code) {
-  background-color: #ebdbb2 !important; /* Gruvbox light1 */
-  color: #458588 !important; /* Gruvbox blue */
-  padding: 0.1em 0.3em !important;
-  border-radius: 3px !important;
-  font-family: var(--codeFont) !important;
-}
-
-.page article pre:not(.callout pre) {
-  background-color: #ebdbb2 !important; /* Gruvbox light1 */
-  color: #3c3836 !important; /* Gruvbox dark1 */
-  border-radius: 4px !important;
-  padding: 1rem !important;
-  font-family: var(--codeFont) !important;
-}
-
-// Blockquotes with simple gray styling - only for regular content, not callouts
-.page article blockquote:not(.callout) {
-  border-left: 3px solid #666 !important; /* Simple gray */
-  color: #333 !important; /* Dark gray text */
-  background-color: #f5f5f5 !important; /* Light gray background */
-  padding: 1rem 1.5rem !important;
-  margin: 1.5rem 0 !important;
-  font-style: italic !important;
-  border-radius: 4px !important;
-}
-
-// Override the base blockquote styling to use gray instead of var(--secondary)
-blockquote {
-  border-left-color: #666 !important; /* Simple gray border instead of red */
-}
-
-// Colorful Callouts - Matching the Showcase Image
-// ===============================================
-
-// Color variables for callouts matching the image
 :root {
-  --callout-border-width: 1px;
-  --callout-border-opacity: 0.8;
-  --callout-default: 69, 133, 136; /* Blue for info */
-  --callout-summary: 104, 157, 106; /* Green for summary/abstract */
-  --callout-info: 69, 133, 136; /* Blue for info */
-  --callout-todo: 69, 133, 136; /* Blue for todo */
-  --callout-important: 104, 157, 106; /* Green for important */
-  --callout-tip: 104, 157, 106; /* Green for tip */
-  --callout-success: 104, 157, 106; /* Green for success */
-  --callout-question: 215, 153, 33; /* Yellow for question */
-  --callout-warning: 214, 93, 14; /* Orange for warning */
-  --callout-fail: 204, 36, 29; /* Red for failure */
-  --callout-error: 204, 36, 29; /* Red for error */
-  --callout-bug: 204, 36, 29; /* Red for bug */
-  --callout-example: 177, 98, 134; /* Purple for example */
-  --callout-quote: 146, 131, 116; /* Beige for quote */
+  --dark0-hard_x: 29, 32, 33;
+  --dark0-hard: rgb(var(--dark0-hard_x));
+  --dark0_x: 40, 40, 40;
+  --dark0: rgb(var(--dark0_x));
+  --dark1_x: 60, 56, 54;
+  --dark1: rgb(var(--dark1_x));
+  --dark2_x: 80, 73, 69;
+  --dark2: rgb(var(--dark2_x));
+  --dark3_x: 102, 92, 84;
+  --dark3: rgb(var(--dark3_x));
+  --gray_x: 146, 131, 116;
+  --light0-hard_x: 249, 245, 215;
+  --light0-hard: rgb(var(--light0-hard_x));
+  --light0_x: 251, 241, 199;
+  --light0: rgb(var(--light0_x));
+  --light1_x: 235, 219, 178;
+  --light1: rgb(var(--light1_x));
+  --light2_x: 213, 196, 161;
+  --light2: rgb(var(--light2_x));
+  --light4_x: 168, 153, 132;
+  --light4: rgb(var(--light4_x));
+  --bright-yellow_x: 250, 189, 47;
+  --bright-yellow: rgb(var(--bright-yellow_x));
+  --bright-blue_x: 131, 165, 152;
+  --bright-blue: rgb(var(--bright-blue_x));
+  --bright-purple_x: 211, 134, 155;
+  --bright-purple: rgb(var(--bright-purple_x));
+  --bright-aqua_x: 142, 192, 124;
+  --bright-aqua: rgb(var(--bright-aqua_x));
+  --neutral-red_x: 204, 36, 29;
+  --neutral-red: rgb(var(--neutral-red_x));
+  --neutral-green_x: 152, 151, 26;
+  --neutral-green: rgb(var(--neutral-green_x));
+  --neutral-yellow_x: 215, 153, 33;
+  --neutral-yellow: rgb(var(--neutral-yellow_x));
+  --neutral-blue_x: 69, 133, 136;
+  --neutral-blue: rgb(var(--neutral-blue_x));
+  --neutral-purple_x: 177, 98, 134;
+  --neutral-purple: rgb(var(--neutral-purple_x));
+  --neutral-aqua_x: 104, 157, 106;
+  --neutral-aqua: rgb(var(--neutral-aqua_x));
+  --neutral-orange_x: 214, 93, 14;
+  --neutral-orange: rgb(var(--neutral-orange_x));
+  --faded-blue_x: 7, 102, 120;
+  --faded-blue: rgb(var(--faded-blue_x));
+
+  --quartz-themes-title-font-size: 1.75rem;
 }
-
-.callout {
-  --callout-color: var(--callout-default) !important;
-  overflow: hidden !important;
-  border-style: solid !important;
-  border-color: rgba(var(--callout-color), var(--callout-border-opacity)) !important;
-  border-width: var(--callout-border-width) !important;
-  border-radius: 4px !important;
-  margin: 1em 0 !important;
-  padding: 12px 12px 12px 24px !important;
-  background-color: rgba(var(--callout-color), 0.15) !important;
-
-  &[data-callout] {
-    --callout-color: var(--callout-default) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="abstract"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="summary"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="tldr"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="info"] {
-    --callout-color: var(--callout-info) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="todo"] {
-    --callout-color: var(--callout-todo) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="important"] {
-    --callout-color: var(--callout-important) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="tip"] {
-    --callout-color: var(--callout-tip) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="hint"] {
-    --callout-color: var(--callout-tip) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="success"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="check"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="done"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="question"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="help"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="faq"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="warning"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="caution"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="attention"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="failure"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="fail"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="missing"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="danger"] {
-    --callout-color: var(--callout-error) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="error"] {
-    --callout-color: var(--callout-error) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="bug"] {
-    --callout-color: var(--callout-bug) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="example"] {
-    --callout-color: var(--callout-example) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="quote"] {
-    --callout-color: var(--callout-quote) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="cite"] {
-    --callout-color: var(--callout-quote) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
+html {
+  font-size: 16px;
+  font-family: var(--bodyFont);
 }
-
-.callout-title {
-  padding: 0 !important;
-  display: flex !important;
-  gap: 4px !important;
-  font-size: inherit !important;
-  color: rgb(var(--callout-color)) !important;
-  line-height: 1.3 !important;
-  align-items: flex-start !important;
-  font-weight: 600 !important;
-  margin-bottom: 0.5rem !important;
-
-  & > .callout-title-inner > p {
-    font-weight: 600 !important;
-    color: inherit !important;
-  }
-
-  .callout-title-inner {
-    font-weight: 600 !important;
-    color: inherit !important;
-  }
-}
-
-.callout-content {
-  overflow-x: auto;
+body {
+  --bold-modifier: 200;
+  --bold-color: inherit;
+  --border-width: 1px;
+  --callout-padding: var(--size-4-3) var(--size-4-3) var(--size-4-3) var(--size-4-6);
+  --callout-radius: var(--radius-s);
+  --callout-blend-mode: var(--highlight-mix-blend-mode);
+  --callout-title-color: inherit;
+  --callout-title-padding: 0;
+  --callout-title-size: inherit;
+  --callout-title-weight: calc(var(--font-weight) + var(--bold-modifier));
+  --callout-content-padding: 0;
+  --callout-content-background: transparent;
+  --caret-color: var(--text-normal);
+  --checkbox-size: var(--font-text-size);
+  --checkbox-marker-color: var(--background-primary);
+  --checkbox-color: var(--interactive-accent);
+  --checkbox-color-hover: var(--interactive-accent-hover);
+  --checkbox-border-color: var(--text-faint);
+  --checkbox-border-color-hover: var(--text-muted);
+  --code-white-space: pre-wrap;
+  --code-border-width: 0px;
+  --code-border-color: var(--background-modifier-border);
+  --code-radius: var(--radius-s);
+  --code-size: var(--font-smaller);
+  --code-background: var(--background-primary-alt);
+  --code-normal: var(--text-normal);
+  --code-comment: var(--text-faint);
+  --code-function: var(--color-yellow);
+  --code-important: var(--color-orange);
+  --code-keyword: var(--color-pink);
+  --code-property: var(--color-cyan);
+  --code-punctuation: var(--text-muted);
+  --code-string: var(--color-green);
+  --code-tag: var(--color-red);
+  --code-value: var(--color-purple);
+  --collapse-icon-color: var(--text-faint);
+  --collapse-icon-color-collapsed: var(--text-accent);
+  --cursor: default;
+  --cursor-link: pointer;
+  --font-smaller: 0.875em;
+  --font-ui-smaller: 12px;
+  --font-ui-small: 13px;
+  --font-ui-medium: 15px;
+  --font-weight: var(--font-normal);
+  --font-normal: 400;
+  --font-medium: 500;
+  --graph-line: var(--color-base-35, var(--background-modifier-border-focus));
+  --graph-node-unresolved: var(--text-faint);
+  --graph-node-tag: var(--color-green);
+  --h1-color: inherit;
+  --h2-color: inherit;
+  --h3-color: inherit;
+  --h4-color: inherit;
+  --h5-color: inherit;
+  --h6-color: inherit;
+  --h1-font: inherit;
+  --h2-font: inherit;
+  --h3-font: inherit;
+  --h4-font: inherit;
+  --h5-font: inherit;
+  --h6-font: inherit;
+  --h1-line-height: 1.2;
+  --h2-line-height: 1.2;
+  --h3-line-height: 1.3;
+  --h4-line-height: 1.4;
+  --h5-line-height: var(--line-height-normal);
+  --h6-line-height: var(--line-height-normal);
+  --h1-size: 1.802em;
+  --h2-size: 1.602em;
+  --h3-size: 1.424em;
+  --h4-size: 1.266em;
+  --h5-size: 1.125em;
+  --h6-size: 1em;
+  --h1-style: normal;
+  --h2-style: normal;
+  --h3-style: normal;
+  --h4-style: normal;
+  --h5-style: normal;
+  --h6-style: normal;
+  --h1-variant: normal;
+  --h2-variant: normal;
+  --h3-variant: normal;
+  --h4-variant: normal;
+  --h5-variant: normal;
+  --h6-variant: normal;
+  --h1-weight: 700;
+  --h2-weight: 600;
+  --h3-weight: 600;
+  --h4-weight: 600;
+  --h5-weight: 600;
+  --h6-weight: 600;
+  --hr-color: var(--background-modifier-border);
+  --hr-thickness: 2px;
+  --icon-color: var(--text-muted);
+  --indentation-guide-width: 1px;
+  --indentation-guide-color: rgba(var(--mono-rgb-100), 0.12);
+  --inline-title-color: var(--h1-color);
+  --inline-title-font: var(--h1-font);
+  --input-height: 30px;
+  --input-radius: 5px;
+  --input-border-width: 1px;
+  --italic-color: inherit;
+  --layer-popover: 30;
+  --line-height-normal: 1.5;
+  --line-height-tight: 1.3;
+  --link-color: var(--text-accent);
+  --link-color-hover: var(--text-accent-hover);
+  --link-decoration-thickness: auto;
+  --link-weight: var(--font-weight);
+  --link-external-color: var(--text-accent);
+  --link-external-color-hover: var(--text-accent-hover);
+  --link-external-filter: none;
+  --link-unresolved-color: var(--text-accent);
+  --link-unresolved-opacity: 0.7;
+  --link-unresolved-filter: none;
+  --link-unresolved-decoration-style: solid;
+  --link-unresolved-decoration-color: hsla(var(--interactive-accent-hsl), 0.3);
+  --nav-item-size: var(--font-ui-small);
+  --nav-item-color: var(--text-muted);
+  --nav-item-color-active: var(--text-normal);
+  --nav-item-background-active: var(--background-modifier-hover);
+  --nav-item-padding: var(--size-4-1) var(--size-4-2) var(--size-4-1) var(--size-4-6);
+  --nav-item-children-padding-start: var(--size-2-2);
+  --nav-item-children-margin-start: var(--size-4-3);
+  --nav-item-weight: inherit;
+  --nav-item-weight-active: inherit;
+  --nav-indentation-guide-width: var(--indentation-guide-width);
+  --nav-indentation-guide-color: var(--indentation-guide-color);
+  --nav-heading-color: var(--text-normal);
+  --nav-heading-weight: var(--font-medium);
+  --metadata-input-text-color: var(--text-normal);
+  --p-spacing: 1rem;
+  --popover-max-height: 95vh;
+  --prompt-input-height: 40px;
+  --prompt-border-width: var(--border-width);
+  --prompt-border-color: var(--color-base-40, var(--background-modifier-border-focus));
+  --radius-s: 4px;
+  --radius-m: 8px;
+  --radius-l: 12px;
+  --scrollbar-active-thumb-bg: rgba(var(--mono-rgb-100), 0.2);
+  --scrollbar-bg: rgba(var(--mono-rgb-100), 0.05);
+  --scrollbar-thumb-bg: rgba(var(--mono-rgb-100), 0.1);
+  --search-icon-color: var(--text-muted);
+  --size-2-1: 2px;
+  --size-2-2: 4px;
+  --size-4-1: 4px;
+  --size-4-2: 8px;
+  --size-4-3: 12px;
+  --size-4-4: 16px;
+  --size-4-6: 24px;
+  --size-4-12: 48px;
+  --tag-size: var(--font-smaller);
+  --tag-color: var(--text-accent);
+  --tag-color-hover: var(--text-accent);
+  --tag-background: hsla(var(--interactive-accent-hsl), 0.1);
+  --tag-background-hover: hsla(var(--interactive-accent-hsl), 0.2);
+  --tag-border-color: hsla(var(--interactive-accent-hsl), 0.15);
+  --tag-border-color-hover: hsla(var(--interactive-accent-hsl), 0.15);
+  --tag-border-width: 0px;
+  --tag-weight: inherit;
+  --background-primary: var(--color-base-00);
+  --background-primary-alt: var(--color-base-10);
+  --background-secondary: var(--color-base-20);
+  --background-modifier-hover: rgba(var(--mono-rgb-100), 0.067);
+  --background-modifier-border: var(--color-base-30);
+  --background-modifier-border-hover: var(--color-base-35);
+  --background-modifier-border-focus: var(--color-base-40);
+  --background-modifier-form-field: var(--color-base-00);
+  --text-normal: var(--color-base-100);
+  --text-muted: var(--color-base-70);
+  --text-faint: var(--color-base-50);
+  --text-highlight-bg-rgb: 255, 208, 0;
+  --text-highlight-bg: rgba(var(--text-highlight-bg-rgb), 0.4);
+  --text-accent: var(--color-accent);
+  --text-accent-hover: var(--color-accent-2);
+  --interactive-accent-hsl: var(--color-accent-hsl);
+  --interactive-accent: var(--color-accent-1);
+  --interactive-accent-hover: var(--color-accent-2);
+  --font-default:
+    ui-sans-serif, -apple-system, BlinkMacSystemFont, system-ui, "Segoe UI", Roboto, "Inter",
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+  --font-monospace-default:
+    ui-monospace, SFMono-Regular, "Cascadia Mono", "Roboto Mono", "DejaVu Sans Mono",
+    "Liberation Mono", Menlo, Monaco, "Consolas", "Source Code Pro", monospace;
+  --font-interface-override: "??";
+  --font-interface-theme: "??";
+  --font-interface:
+    var(--font-interface-override), var(--font-interface-theme), var(--default-font, "??"),
+    var(--font-default);
+  --font-text-override: "??";
+  --font-text-theme: "??";
+  --font-print-override: "??";
+  --font-print:
+    var(--font-print-override), var(--font-text-override), var(--font-text-theme), "Arial";
+  --font-monospace-override: "??";
+  --font-monospace-theme: "??";
+  --font-monospace:
+    var(--font-monospace-override), var(--font-monospace-theme), var(--font-monospace-default);
+  --font-text-size: 16px;
+  margin: 0;
+  overscroll-behavior: none;
   padding: 0;
-  background-color: transparent;
-}
+  width: 100%;
+  text-rendering: optimizeLegibility;
+  font-family: var(--font-interface);
+  line-height: var(--line-height-tight);
+  font-size: var(--font-ui-medium);
+  background-color: var(--background-primary);
+  color: var(--text-normal);
+  -webkit-tap-highlight-color: #ffffff;
+  user-select: none;
+  -webkit-user-select: none;
+  caret-color: var(--caret-color);
+  --accent-h: 12;
+  --accent-s: 107%;
+  --accent-l: 32%;
+  --link-decoration: none;
+  --link-decoration-hover: none;
+  --link-external-decoration: none;
+  --link-external-decoration-hover: none;
+  --tag-decoration: none;
+  --tag-decoration-hover: underline;
+  --tag-padding-x: 0.5em;
+  --tag-padding-y: 0.2em;
+  --tag-radius: 0.5em;
+  --bold-weight: 600;
+  --checkbox-radius: 0;
+  --callout-border-width: 1px;
+  --callout-border-opacity: 0.4;
+  --callout-default: var(--neutral-blue_x);
+  --callout-summary: var(--neutral-aqua_x);
+  --callout-info: var(--neutral-blue_x);
+  --callout-todo: var(--neutral-blue_x);
+  --callout-important: var(--neutral-aqua_x);
+  --callout-tip: var(--neutral-aqua_x);
+  --callout-success: var(--neutral-green_x);
+  --callout-question: var(--neutral-yellow_x);
+  --callout-warning: var(--neutral-orange_x);
+  --callout-fail: var(--neutral-red_x);
+  --callout-error: var(--neutral-red_x);
+  --callout-bug: var(--neutral-red_x);
+  --callout-example: var(--neutral-purple_x);
+  --callout-quote: var(--gray_x);
+  contain: initial;
+  height: auto;
+  overflow: auto;
+  padding-top: 0;
+  --font-text: var(--font-print);
 
-// put your custom CSS here!
+  --quartz-themes-title-font-size: 1.75rem;
+}
+:root,
+html {
+  .callout {
+    --callout-color: var(--callout-default);
+    overflow: hidden;
+    border-style: solid;
+    border-color: rgba(var(--callout-color), var(--callout-border-opacity));
+    border-width: var(--callout-border-width);
+    border-radius: var(--callout-radius);
+    margin: 1em 0;
+    mix-blend-mode: var(--callout-blend-mode);
+    padding: var(--callout-padding);
+    background-color: rgba(var(--callout-color), 0.2);
+
+    background-color: rgba(var(--callout-color), 0.2);
+
+    overflow-x: auto;
+    overflow-y: hidden;
+
+    &[data-callout] {
+      --callout-color: var(--callout-default);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="abstract"] {
+      --callout-color: var(--callout-summary);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="summary"] {
+      --callout-color: var(--callout-summary);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="tldr"] {
+      --callout-color: var(--callout-summary);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="info"] {
+      --callout-color: var(--callout-info);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="todo"] {
+      --callout-color: var(--callout-todo);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="important"] {
+      --callout-color: var(--callout-important);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="tip"] {
+      --callout-color: var(--callout-tip);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="hint"] {
+      --callout-color: var(--callout-tip);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="success"] {
+      --callout-color: var(--callout-success);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="check"] {
+      --callout-color: var(--callout-success);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="done"] {
+      --callout-color: var(--callout-success);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="question"] {
+      --callout-color: var(--callout-question);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="help"] {
+      --callout-color: var(--callout-question);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="faq"] {
+      --callout-color: var(--callout-question);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="warning"] {
+      --callout-color: var(--callout-warning);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="caution"] {
+      --callout-color: var(--callout-warning);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="attention"] {
+      --callout-color: var(--callout-warning);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="failure"] {
+      --callout-color: var(--callout-fail);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="fail"] {
+      --callout-color: var(--callout-fail);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="missing"] {
+      --callout-color: var(--callout-fail);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="danger"] {
+      --callout-color: var(--callout-error);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="error"] {
+      --callout-color: var(--callout-error);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="bug"] {
+      --callout-color: var(--callout-bug);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="example"] {
+      --callout-color: var(--callout-example);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="quote"] {
+      --callout-color: var(--callout-quote);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+    &[data-callout="cite"] {
+      --callout-color: var(--callout-quote);
+
+      background-color: rgba(var(--callout-color), 0.2);
+    }
+  }
+
+  .callout-title {
+    padding: var(--callout-title-padding);
+    display: flex;
+    gap: var(--size-4-1);
+    font-size: var(--callout-title-size);
+    color: rgb(var(--callout-color));
+    line-height: var(--line-height-tight);
+    align-items: flex-start;
+
+    & > .callout-title-inner > p {
+      --font-weight: var(--callout-title-weight);
+      font-weight: var(--font-weight);
+      color: var(--callout-title-color);
+    }
+
+    .callout-title-inner {
+      --font-weight: var(--callout-title-weight);
+      font-weight: var(--font-weight);
+      color: var(--callout-title-color);
+    }
+  }
+
+  & > .callout-content {
+    overflow-x: auto;
+    padding: var(--callout-content-padding);
+    background-color: var(--callout-content-background);
+  }
+}
+body {
+  --quartz-text-highlight: var(--text-highlight-bg, var(--background-modifier-hover)) !important;
+
+  background-color: var(--background-primary);
+
+  background-color: var(--background-primary);
+
+  overflow: initial;
+
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb-bg) var(--scrollbar-bg);
+
+  ::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+    -webkit-border-radius: var(--radius-l);
+    background-color: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb-bg);
+    -webkit-border-radius: var(--radius-l);
+    background-clip: padding-box;
+    border: 2px solid transparent;
+    border-width: 3px 3px 3px 2px;
+    min-height: 45px;
+
+    &:hover {
+      background-color: var(--scrollbar-active-thumb-bg);
+    }
+
+    &:active {
+      -webkit-border-radius: var(--radius-l);
+      background-color: var(--scrollbar-active-thumb-bg);
+    }
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  @media all and ($desktop) {
+    background-color: var(--background-secondary);
+
+    background-color: var(--background-primary);
+
+    > #quartz-root {
+      background-color: var(--background-primary);
+
+      background-color: var(--background-primary);
+    }
+  }
+
+  @media all and ($mobile) {
+    div.flex-component > div:has(> button.readermode) {
+      display: none;
+    }
+  }
+
+  @media all and not ($mobile) {
+    .page > #quartz-body {
+      padding-left: 0;
+    }
+  }
+
+  section,
+  .page > #quartz-body .sidebar {
+    &.left,
+    &.left:has(.explorer),
+    &.right {
+      background-color: var(--background-primary);
+    }
+    @media all and not ($desktop) {
+      &.right {
+        background-color: var(--background-primary);
+      }
+    }
+    @media all and ($mobile) {
+      &.left:has(.explorer) {
+        :not(.folder-container, a[data-for]):before,
+        :after {
+          background-color: var(--background-primary);
+
+          content: " ";
+          display: block;
+          height: 100%;
+          width: 1rem;
+          top: 0;
+          position: absolute;
+        }
+        :not(.folder-container, a[data-for]):before {
+          left: -1rem;
+        }
+        a.folder-title:before {
+          height: unset;
+        }
+        :after {
+          right: -1rem;
+        }
+      }
+    }
+    @media all and ($tablet) {
+      &.left:has(.explorer):before {
+        padding-left: 1rem;
+      }
+    }
+  }
+
+  .highlight,
+  ::selection,
+  ::-moz-selection {
+    background: var(--quartz-text-highlight, var(--tertiary));
+  }
+
+  a,
+  footer a {
+    --font-weight: var(--link-weight);
+    color: var(--text-a, var(--link-color));
+    font-weight: var(--link-weight);
+    outline: none;
+
+    cursor: var(--cursor-link);
+    transition: opacity 0.15s ease-in-out;
+    background-position: center right;
+    background-repeat: no-repeat;
+
+    --font-weight: var(--link-weight);
+    color: var(--link-color);
+    font-weight: var(--link-weight);
+    outline: none;
+    text-decoration-line: var(--link-decoration);
+    text-decoration-thickness: var(--link-decoration-thickness);
+    cursor: var(--cursor-link);
+    transition: opacity 0.15s ease-in-out;
+
+    text-decoration-line: none;
+
+    &:hover {
+      color: var(--text-a-hover, var(--link-color-hover));
+
+      color: var(--link-color-hover);
+      text-decoration-line: var(--link-decoration-hover);
+
+      text-decoration-line: none;
+    }
+    &.internal {
+      color: var(--text-a, var(--link-color));
+      background-color: color-mix(in srgb, var(--text-a, var(--link-color)), #0000 85%);
+
+      color: var(--link-color);
+      cursor: var(--cursor-link);
+      text-decoration-line: var(--link-decoration);
+      transition: opacity 0.15s ease-in-out;
+
+      text-decoration-line: none;
+      &.tag-link {
+        --highlight-fallback: 258, 88%, 66%;
+        color: var(--tag-color, var(--text-accent));
+        text-decoration: var(--tag-decoration, none);
+        background-color: var(
+          --tag-background,
+          hsla(
+            var(--interactive-accent-hsl, var(--color-accent-hsl, var(--highlight-fallback))),
+            0.1
+          )
+        );
+
+        background-color: var(--tag-background);
+        border: var(--tag-border-width) solid var(--tag-border-color);
+        border-radius: var(--tag-radius);
+        color: var(--tag-color);
+        font-size: var(--tag-size);
+        font-weight: var(--tag-weight);
+        text-decoration: var(--tag-decoration);
+        padding: var(--tag-padding-y) var(--tag-padding-x);
+        line-height: 1;
+
+        text-decoration-line: none;
+        &:hover {
+          color: var(--tag-color-hover, var(--text-accent));
+          text-decoration: var(--tag-decoration-hover, none);
+          background-color: var(
+            --tag-background-hover,
+            hsla(var(--interactive-accent-hsl, var(--highlight-fallback)), 0.2)
+          );
+
+          background-color: var(--tag-background-hover);
+          border: var(--tag-border-width) solid var(--tag-border-color-hover);
+          color: var(--tag-color-hover);
+          text-decoration: var(--tag-decoration-hover);
+        }
+      }
+
+      &.broken {
+        color: var(--link-unresolved-color);
+        filter: var(--link-unresolved-filter);
+        opacity: var(--link-unresolved-opacity);
+        text-decoration-color: var(--link-unresolved-decoration-color);
+        text-decoration-style: var(--link-unresolved-decoration-style);
+
+        text-decoration-line: none;
+        &:hover {
+          color: var(--link-color-hover);
+          opacity: 1;
+          text-decoration-color: var(--link-color-hover);
+          text-decoration-line: var(--link-decoration-hover);
+        }
+      }
+    }
+    &.external {
+      color: var(--link-external-color);
+
+      background-position: center right;
+      background-repeat: no-repeat;
+      background-image: linear-gradient(transparent, transparent);
+      background-color: transparent;
+
+      cursor: var(--cursor-link);
+      filter: var(--link-external-filter);
+      transition: opacity 0.15s ease-in-out;
+
+      color: var(--link-external-color);
+      text-decoration-line: var(--link-external-decoration);
+      background-position: center right;
+      background-repeat: no-repeat;
+      background-image:
+        linear-gradient(transparent, transparent),
+        url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22currentColor%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M18%2013v6a2%202%200%200%201-2%202H6a2%202%200%200%201-2-2V8a2%202%200%200%201%202-2h6%22/%3E%3Cpolyline%20points%3D%2215%203%2021%203%2021%209%22/%3E%3Cline%20x1%3D%2210%22%20y1%3D%2214%22%20x2%3D%2221%22%20y2%3D%223%22/%3E%3C/svg%3E");
+      background-size: 0.825em;
+      padding-inline-end: 0.9em;
+      background-position-y: 0.25em;
+      cursor: var(--cursor-link);
+      filter: var(--link-external-filter);
+      transition: opacity 0.15s ease-in-out;
+
+      &:hover {
+        color: var(--link-external-color-hover);
+
+        color: var(--link-external-color-hover);
+        text-decoration-line: var(--link-external-decoration-hover);
+      }
+    }
+  }
+
+  a.tag {
+    background-color: var(--tag-background);
+    border: var(--tag-border-width) solid var(--tag-border-color);
+    border-radius: var(--tag-radius);
+    color: var(--tag-color);
+
+    font-weight: var(--tag-weight);
+
+    background-color: var(--tag-background);
+    border: var(--tag-border-width) solid var(--tag-border-color);
+    border-radius: var(--tag-radius);
+    color: var(--tag-color);
+    font-size: var(--tag-size);
+    font-weight: var(--tag-weight);
+    text-decoration: var(--tag-decoration);
+    padding: var(--tag-padding-y) var(--tag-padding-x);
+    line-height: 1;
+
+    &:hover {
+      background-color: var(--tag-background-hover);
+      border: var(--tag-border-width) solid var(--tag-border-color-hover);
+      color: var(--tag-color-hover);
+      text-decoration: var(--tag-decoration-hover);
+
+      background-color: var(--tag-background-hover);
+      border: var(--tag-border-width) solid var(--tag-border-color-hover);
+      color: var(--tag-color-hover);
+      text-decoration: var(--tag-decoration-hover);
+    }
+  }
+  input[type="checkbox"] {
+    appearance: none;
+    appearance: none;
+    border-radius: var(--checkbox-radius);
+    border: 1px solid var(--checkbox-border-color);
+    flex-shrink: 0;
+    padding: 0;
+    margin: 0;
+    margin-inline-end: 6px;
+    width: var(--checkbox-size);
+    height: var(--checkbox-size);
+    position: relative;
+    transition: box-shadow 0.15s ease-in-out;
+  }
+  input[type="checkbox"]:hover,
+  input[type="checkbox"]:active,
+  input[type="checkbox"]:focus {
+    outline: 0;
+    border-color: var(--checkbox-border-color-hover);
+  }
+  input[type="checkbox"]:focus-visible {
+    box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
+  }
+  input[type="checkbox"]:checked:after {
+    content: "";
+    top: -1.5px;
+    inset-inline-start: -2px;
+    position: absolute;
+    width: var(--checkbox-size);
+    height: var(--checkbox-size);
+    display: block;
+    background-color: var(--checkbox-marker-color);
+    transform: rotate(0deg);
+    mask-position: 52% 52%;
+    mask-size: 65%;
+    mask-repeat: no-repeat;
+    mask-image: url('data:image/svg+xml; utf8, <svg width="12px" height="10px" viewBox="0 0 12 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-4.000000, -6.000000)" fill="%23000000"><path d="M8.1043257,14.0367999 L4.52468714,10.5420499 C4.32525014,10.3497722 4.32525014,10.0368095 4.52468714,9.8424863 L5.24777413,9.1439454 C5.44721114,8.95166768 5.77142411,8.95166768 5.97086112,9.1439454 L8.46638057,11.5903727 L14.0291389,6.1442083 C14.2285759,5.95193057 14.5527889,5.95193057 14.7522259,6.1442083 L15.4753129,6.84377194 C15.6747499,7.03604967 15.6747499,7.35003511 15.4753129,7.54129009 L8.82741268,14.0367999 C8.62797568,14.2290777 8.3037627,14.2290777 8.1043257,14.0367999"></path></g></g></svg>');
+  }
+  input[type="checkbox"]:checked {
+    background-color: var(--checkbox-color);
+    border-color: var(--checkbox-color);
+  }
+  @media (hover: hover) {
+    input[type="checkbox"]:checked:hover {
+      background-color: var(--checkbox-color-hover);
+      border-color: var(--checkbox-color-hover);
+    }
+  }
+  input[type="checkbox"][data-indeterminate="true"]:not(:checked):after {
+    content: "";
+    position: absolute;
+    top: calc(var(--checkbox-size) / 2 - 2px);
+    width: calc(var(--checkbox-size) - 6px);
+    left: 0;
+    right: 0;
+    margin: 0 auto;
+    height: 2px;
+    display: block;
+    border-radius: 2px;
+    background-color: var(--text-normal);
+  }
+
+  h1 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h1-weight);
+    color: var(--h1-color);
+    font-family: var(--h1-font);
+    font-size: var(--h1-size);
+    font-style: var(--h1-style);
+    font-variant: var(--h1-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: -0.015em;
+    line-height: var(--h1-line-height);
+
+    font-size: 2rem;
+  }
+  h1 a {
+    --link-weight: var(--h1-weight);
+  }
+  h2.page-title,
+  h2.page-title a,
+  h2 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h2-weight);
+    color: var(--h2-color);
+    font-family: var(--h2-font);
+    font-size: var(--h2-size);
+    font-style: var(--h2-style);
+    font-variant: var(--h2-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: -0.015em;
+    line-height: var(--h2-line-height);
+
+    font-size: 1.75rem;
+  }
+  h2 a {
+    --link-weight: var(--h2-weight);
+  }
+  h3 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h3-weight);
+    color: var(--h3-color);
+    font-family: var(--h3-font);
+    font-size: var(--h3-size);
+    font-style: var(--h3-style);
+    font-variant: var(--h3-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: -0.015em;
+    line-height: var(--h3-line-height);
+
+    font-size: 1.6rem;
+  }
+  h3 a {
+    --link-weight: var(--h3-weight);
+  }
+  h4 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h4-weight);
+    color: var(--h4-color);
+    font-family: var(--h4-font);
+    font-size: var(--h4-size);
+    font-style: var(--h4-style);
+    font-variant: var(--h4-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: 0.015em;
+    line-height: var(--h4-line-height);
+
+    font-size: 1.4rem;
+  }
+  h4 a {
+    --link-weight: var(--h4-weight);
+  }
+  h5 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h5-weight);
+    color: var(--h5-color);
+    font-family: var(--h5-font);
+    font-size: var(--h5-size);
+    font-style: var(--h5-style);
+    font-variant: var(--h5-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: 0.015em;
+    line-height: var(--h5-line-height);
+
+    font-size: 1.2rem;
+  }
+  h5 a {
+    --link-weight: var(--h5-weight);
+  }
+  h6 {
+    margin-block-end: var(--p-spacing);
+    margin-block-start: var(--p-spacing);
+    --font-weight: var(--h6-weight);
+    color: var(--h6-color);
+    font-family: var(--h6-font);
+    font-size: var(--h6-size);
+    font-style: var(--h6-style);
+    font-variant: var(--h6-variant);
+    font-weight: var(--font-weight);
+    letter-spacing: 0.015em;
+    line-height: var(--h6-line-height);
+
+    font-size: 1.1rem;
+  }
+  h6 a {
+    --link-weight: var(--h6-weight);
+  }
+  h1,
+  h1 a,
+  h2.page-title,
+  h2.page-title a,
+  h2,
+  h2 a,
+  h3,
+  h3 a,
+  h4,
+  h4 a,
+  h5,
+  h5 a,
+  h6,
+  h6 a {
+    margin-block: 0;
+  }
+
+  figure[data-rehype-pretty-code-figure] pre,
+  pre {
+    position: relative;
+    padding: var(--size-4-3) var(--size-4-4);
+    min-height: 38px;
+    background-color: var(--code-background);
+    border-radius: var(--code-radius);
+    white-space: var(--code-white-space);
+    border: var(--code-border-width) solid var(--code-border-color);
+    overflow-x: auto;
+
+    white-space: pre;
+    & > code {
+      border: none;
+      padding: 0;
+      background-color: transparent;
+
+      span[style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;"] {
+        //color: var(--code-value) !important;
+        color: var(--color-purple) !important;
+      }
+      span[style="--shiki-light:#005CC5;--shiki-dark:#79B8FF;"] {
+        //color: var(--code-function) !important;
+        color: var(--color-blue) !important;
+      }
+      span[style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;"] {
+        //color: var(--code-string) !important;
+        color: var(--color-cyan) !important;
+      }
+      span[style="--shiki-light:#032F62;--shiki-dark:#DBEDFF;"] {
+        //color: var(--code-property) !important;
+        color: var(--code-yellow) !important;
+      }
+      span[style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;"] {
+        //color: var(--code-normal) !important;
+        color: var(--code-normal) !important;
+      }
+      span[style="--shiki-light:#586069;--shiki-dark:#D1D5DA;"] {
+        //color: var(--code-punctuation) !important;
+        color: var(--text-muted) !important;
+      }
+      span[style="--shiki-light:#F6F8FA;--shiki-dark:#2F363D;"] {
+        //color: var(--code-comment) !important;
+        color: var(--text-faint) !important;
+      }
+      span[style="--shiki-light:#6A737D;--shiki-dark:#6A737D;"] {
+        //color: var(--code-comment) !important;
+        color: var(--code-comment) !important;
+      }
+      span[style="--shiki-light:#22863A;--shiki-dark:#85E89D;"] {
+        //color: var(--code-tag) !important;
+        color: var(--color-green) !important;
+      }
+      span[style="--shiki-light:#E36209;--shiki-dark:#FFAB70;"] {
+        //color: var(--code-important) !important;
+        color: var(--color-orange) !important;
+      }
+      span[style="--shiki-light:#B31D28;--shiki-dark:#FDAEB7;"] {
+        //color: var(--text-operator) !important;
+        color: var(--color-pink) !important;
+      }
+      span[style="--shiki-light:#D73A49;--shiki-dark:#F97583;"] {
+        //color: var(--code-keyword) !important;
+        color: var(--color-red) !important;
+      }
+
+      & {
+        background-color: transparent;
+        color: var(--code-normal);
+        font-family: var(--codeFont, var(--font-monospace));
+      }
+    }
+  }
+
+  code {
+    background-color: var(--code-background);
+    color: var(--code-normal);
+
+    color: var(--code-normal);
+    font-family: var(--font-monospace);
+    background-color: var(--code-background);
+    border-radius: var(--code-radius);
+    font-size: var(--code-size);
+    padding: 0.15em 0.3em;
+    border: var(--code-border-width) solid var(--code-border-color);
+    -webkit-box-decoration-break: clone;
+
+    font-family: var(--codeFont, var(--font-monospace));
+  }
+  .clipboard-button {
+    margin: 6px;
+    padding: 6px 8px;
+    height: auto;
+    background-color: transparent;
+    box-shadow: none;
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    font-family: var(--font-interface);
+    position: absolute;
+    top: 0;
+    inset-inline-end: 0;
+
+    &:hover {
+      background-color: var(--background-modifier-hover);
+    }
+    & > svg {
+      fill: var(--search-icon-color, var(--text-muted, var(--darkgray)));
+    }
+  }
+
+  .content-meta {
+    color: var(--text-normal);
+
+    color: var(--metadata-input-text-color);
+  }
+
+  .breadcrumbs-element p {
+    color: var(--text-faint);
+  }
+
+  .backlinks {
+    h3 {
+      margin-block-end: var(--p-spacing);
+      margin-block-start: var(--p-spacing);
+      --font-weight: var(--h3-weight);
+      color: var(--h3-color);
+      font-family: var(--h3-font);
+      font-size: var(--h3-size);
+      font-style: var(--h3-style);
+      font-variant: var(--h3-variant);
+      font-weight: var(--font-weight);
+      letter-spacing: -0.015em;
+      line-height: var(--h3-line-height);
+    }
+
+    ul li {
+      color: var(--nav-heading-color);
+
+      font-weight: var(--nav-heading-weight);
+    }
+  }
+
+  .explorer {
+    @media all and ($mobile) {
+      margin-top: calc((var(--quartz-themes-title-font-size) - 10px) / 4);
+      &:not(.collapsed) > .explorer-content {
+        -webkit-backdrop-filter: blur(8px);
+        backdrop-filter: blur(8px);
+        padding-left: 1rem;
+      }
+    }
+    button.explorer-toggle,
+    h2 {
+      color: var(--h2-color);
+    }
+    .explorer-content {
+      @media all and ($mobile) {
+        background-color: var(--background-primary);
+
+        left: -1rem;
+      }
+
+      .folder-container {
+        --folder-closed-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 5h-8.586L9.707 3.293A.997.997 0 0 0 9 3H4c-1.103 0-2 .897-2 2v14c0 1.103.897 2 2 2h16c1.103 0 2-.897 2-2V7c0-1.103-.897-2-2-2zM4 19V7h16l.002 12H4z"></path></svg>');
+        --folder-open-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M2.165 19.551c.186.28.499.449.835.449h15c.4 0 .762-.238.919-.606l3-7A.998.998 0 0 0 21 11h-1V8c0-1.103-.897-2-2-2h-6.655L8.789 4H4c-1.103 0-2 .897-2 2v13h.007a1 1 0 0 0 .158.551zM18 8v3H6c-.4 0-.762.238-.919.606L4 14.129V8h14z"></path></svg>');
+
+        color: var(--icon-color);
+
+        text-overflow: ellipsis;
+        position: relative;
+
+        @media all and ($mobile) {
+          padding-inline-start: 0.5rem;
+          padding-inline-end: 0rem;
+          border-radius: 0.25rem;
+        }
+        & > svg {
+          opacity: 0.001;
+          position: absolute;
+        }
+        &:before {
+          width: 1rem;
+          height: 1rem;
+          min-width: 1rem;
+          min-height: 1rem;
+          display: flex;
+          align-self: center;
+          background: var(--icon-color);
+          content: "";
+        }
+        & > div {
+          width: 100%;
+        }
+        &:hover {
+          background-color: var(--nav-item-background-active);
+          color: var(--nav-item-color-active);
+          font-weight: var(--nav-item-weight-active);
+
+          font-size: 1rem;
+          line-height: 1.5rem;
+
+          border-radius: 0.25rem;
+        }
+      }
+      li:has(> .folder-outer:not(.open)) > .folder-container:before {
+        background: var(--collapse-icon-color-collapsed, var(--icon-color));
+        mask-image: var(--folder-closed-icon);
+        -webkit-mask-image: var(--folder-closed-icon);
+      }
+      li:has(> .folder-outer.open) > .folder-container:before {
+        background: var(--collapse-icon-color, var(--icon-color));
+        mask-image: var(--folder-open-icon);
+        -webkit-mask-image: var(--folder-open-icon);
+      }
+      .folder-outer > ul.content {
+        padding-inline-start: var(
+          --nav-item-children-padding-start,
+          var(--nav-item-children-padding-left)
+        );
+        margin-inline-start: var(
+          --nav-item-children-margin-start,
+          var(--nav-item-children-margin-left)
+        );
+        margin-bottom: 1px;
+        border-inline-start: var(--nav-indentation-guide-width) solid
+          var(--nav-indentation-guide-color);
+      }
+      ul.explorer-ul li {
+        text-overflow: ellipsis;
+        position: relative;
+
+        a {
+          color: inherit;
+          line-height: 1.5rem;
+          padding: 6px 8px 6px 24px;
+
+          padding: var(--nav-item-padding);
+          border-radius: var(--radius-s);
+          color: var(--nav-item-color);
+          cursor: var(--cursor);
+          display: flex;
+          font-size: var(--nav-item-size);
+          font-weight: var(--nav-item-weight);
+          line-height: var(--line-height-tight);
+          margin-bottom: var(--size-2-1);
+
+          font-size: 1rem;
+          &.active,
+          &:not(.folder-title):hover {
+            font-size: 1rem;
+            line-height: 1.5rem;
+
+            border-radius: 0.25rem;
+          }
+          &[data-for$="/index"] {
+            padding-inline-start: 0.5rem;
+            padding-inline-end: 0;
+          }
+          padding-inline-start: 0;
+
+          @media all and ($mobile) {
+            padding-inline-start: 0.5rem;
+            padding-inline-end: 0.5rem;
+            &[data-for$="/index"] {
+              padding-inline-end: 0.5rem;
+            }
+          }
+        }
+        > a:before {
+          --file-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill=""><path d="M0 0h24v24H0V0z" fill="none"/><path d="M8 16h8v2H8zm0-4h8v2H8zm6-10H6c-1.1 0-2 .9-2 2v16c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm4 18H6V4h7v5h5v11z"/></svg>');
+          width: 1rem;
+          height: 1rem;
+          min-width: 1rem;
+          min-height: 1rem;
+          content: "";
+          display: flex;
+          align-self: center;
+          background: var(--icon-color);
+          mask-image: var(--file-icon);
+          -webkit-mask-image: var(--file-icon);
+          margin-inline-end: 0.5rem;
+        }
+      }
+    }
+  }
+
+  .toc {
+    color: var(--h3-color);
+
+    button.toc-header {
+      h3 {
+        margin-block-end: var(--p-spacing);
+        margin-block-start: var(--p-spacing);
+        --font-weight: var(--h3-weight);
+        color: var(--h3-color);
+        font-family: var(--h3-font);
+        font-size: var(--h3-size);
+        font-style: var(--h3-style);
+        font-variant: var(--h3-variant);
+        font-weight: var(--font-weight);
+        letter-spacing: -0.015em;
+        line-height: var(--h3-line-height);
+
+        margin-block: 0;
+      }
+      color: inherit;
+
+      color: var(--h3-color);
+    }
+    ul.toc-content.overflow {
+      li,
+      li > a {
+        color: inherit;
+
+        color: var(--nav-item-color);
+
+        font-weight: var(--nav-item-weight);
+
+        font-size: var(--nav-item-size);
+
+        font-size: 1rem;
+      }
+    }
+  }
+
+  .backlinks,
+  .explorer,
+  .graph,
+  .toc {
+    h3 {
+      margin-block-end: var(--p-spacing);
+      margin-block-start: var(--p-spacing);
+      --font-weight: var(--h3-weight);
+      color: var(--h3-color);
+      font-family: var(--h3-font);
+      font-size: var(--h3-size);
+      font-style: var(--h3-style);
+      font-variant: var(--h3-variant);
+      font-weight: var(--font-weight);
+      letter-spacing: -0.015em;
+      line-height: var(--h3-line-height);
+
+      min-height: calc(2 * var(--p-spacing) + var(--h3-line-height));
+      margin-block: 0;
+    }
+  }
+
+  button.readermode {
+    & > svg {
+      display: none;
+    }
+
+    --readermode-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWJvb2stb3Blbi1pY29uIGx1Y2lkZS1ib29rLW9wZW4iPjxwYXRoIGQ9Ik0xMiA3djE0Ii8+PHBhdGggZD0iTTMgMThhMSAxIDAgMCAxLTEtMVY0YTEgMSAwIDAgMSAxLTFoNWE0IDQgMCAwIDEgNCA0IDQgNCAwIDAgMSA0LTRoNWExIDEgMCAwIDEgMSAxdjEzYTEgMSAwIDAgMS0xIDFoLTZhMyAzIDAgMCAwLTMgMyAzIDMgMCAwIDAtMy0zeiIvPjwvc3ZnPg==");
+    background: var(--icon-color) !important;
+    mask-image: var(--readermode-icon);
+    -webkit-mask-image: var(--readermode-icon);
+    width: 24px;
+    height: 24px;
+  }
+
+  button.global-graph-icon {
+    & > svg {
+      display: none;
+    }
+
+    --graph-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWdpdC1mb3JrLWljb24gbHVjaWRlLWdpdC1mb3JrIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjE4IiByPSIzIi8+PGNpcmNsZSBjeD0iNiIgY3k9IjYiIHI9IjMiLz48Y2lyY2xlIGN4PSIxOCIgeT0iNiIgcj0iMyIvPjxwYXRoIGQ9Ik0xOCA5djJjMCAuNi0uNCAxLTEgMUg3Yy0uNiAwLTEtLjQtMS0xVjkiLz48cGF0aCBkPSJNMTIgMTJ2MyIvPjwvc3ZnPg==");
+    background: var(--icon-color) !important;
+    mask-image: var(--graph-icon);
+    -webkit-mask-image: var(--graph-icon);
+    width: 24px;
+    height: 24px;
+  }
+
+  button.darkmode {
+    & > svg {
+      display: none !important;
+    }
+
+    --moon-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLW1vb24taWNvbiBsdWNpZGUtbW9vbiI+PHBhdGggZD0iTTEyIDNhNiA2IDAgMCAwIDkgOSA5IDkgMCAxIDEtOS05WiIvPjwvc3ZnPg==");
+
+    --sun-icon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIxIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLXN1bi1pY29uIGx1Y2lkZS1zdW4iPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjQiLz48cGF0aCBkPSJNMTIgMnYyIi8+PHBhdGggZD0iTTEyIDIwdjIiLz48cGF0aCBkPSJtNC45MyA0LjkzIDEuNDEgMS40MSIvPjxwYXRoIGQ9Im0xNy42NiAxNy42NiAxLjQxIDEuNDEiLz48cGF0aCBkPSJNMiAxMmgyIi8+PHBhdGggZD0iTTIwIDEyaDIiLz48cGF0aCBkPSJtNi4zNCAxNy42Ni0xLjQxIDEuNDEiLz48cGF0aCBkPSJtMTkuMDcgNC45My0xLjQxIDEuNDEiLz48L3N2Zz4=");
+    background: var(--icon-color) !important;
+    width: 24px;
+    height: 24px;
+  }
+
+  .explorer svg,
+  button.toc-header .fold,
+  .global-graph-icon,
+  .readermode,
+  .darkmode {
+    color: var(--icon-color);
+    stroke: var(--icon-color);
+  }
+
+  .search {
+    & > .search-button {
+      background: var(--button-secondary-bg-color);
+      color: var(--button-secondary-fg-color);
+
+      -webkit-app-region: no-drag;
+      background: var(--background-modifier-form-field);
+      border: var(--input-border-width) solid var(--background-modifier-border);
+      border-radius: var(--input-radius);
+      color: var(--text-normal);
+      font-family: inherit;
+      font-size: var(--font-ui-small);
+      outline: none;
+      padding: var(--size-4-1) var(--size-4-2);
+      height: var(--input-height);
+
+      font-size: 1rem;
+      svg {
+        color: var(--search-icon-color, var(--text-muted, var(--darkgray)));
+        stroke: var(--search-icon-color, var(--text-muted, var(--darkgray)));
+      }
+    }
+    & > .search-container {
+      & > .search-space {
+        color: var(--text-normal);
+        background-color: var(--background-secondary);
+        border-color: var(--background-modifier-border, var(--color-base-35));
+
+        background-color: var(--background-primary);
+
+        border: var(--prompt-border-width) solid var(--prompt-border-color);
+
+        border-radius: var(--radius-l);
+
+        box-shadow: var(--shadow-l);
+
+        margin: 12vh auto;
+        & > input {
+          background: transparent;
+
+          width: 100%;
+          padding: var(--size-4-6);
+          padding-inline-end: var(--size-4-12);
+          background-color: var(--background-primary);
+          font-size: var(--font-ui-medium);
+          border: none;
+          height: var(--prompt-input-height);
+          border-radius: 0;
+          border-bottom: 1px solid var(--background-secondary);
+
+          margin-bottom: 0;
+          border-bottom: none;
+          font-size: 1.1rem;
+        }
+        & > * {
+          background: transparent;
+
+          color: var(--text-normal);
+
+          margin-bottom: 0;
+          box-shadow: none;
+        }
+        & > .search-layout {
+          border-color: var(--background-modifier-border, var(--color-base-35));
+          &.display-results {
+            border-color: var(--background-modifier-border, var(--color-base-35));
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+          }
+          & .highlight {
+            background-color: var(--quartz-text-highlight);
+
+            font-weight: bold;
+            color: #fb4934;
+          }
+          & > .preview-container {
+            color: var(--text-normal);
+          }
+          & > .results-container {
+            border-color: var(--background-modifier-border, var(--color-base-35));
+            & .result-card {
+              border-color: var(--background-modifier-border, var(--color-base-35));
+              @media all and not ($mobile) {
+                display: flex;
+                &.no-match {
+                  display: block;
+                }
+              }
+              &:hover,
+              &:focus,
+              &.focus {
+                background-color: var(--background-modifier-hover);
+              }
+              & > ul > li > p {
+                background-color: transparent;
+
+                color: var(--text-normal);
+
+                &.match-tag {
+                  color: var(--tag-color);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .page-title,
+  .page-title a {
+    color: var(--inline-title-color, var(--h1-color, var(--link-color, var(--darkgray))));
+    font-family: var(--inline-title-font, var(--h1-font, var(--font-text, inherit)));
+    font-size: var(--quartz-themes-title-font-size, 1.75rem);
+  }
+
+  .graph {
+    & > .graph-outer {
+      border: 1px solid var(--background-modifier-border-hover, var(--color-base-35));
+      --background-modifier-border-focus: var(--color-base-40);
+      & > .global-graph-icon {
+        color: var(--search-icon-color, var(--text-muted, var(--darkgray)));
+        &:hover {
+          background-color: var(--background-modifier-hover);
+        }
+      }
+    }
+    & > .global-graph-outer {
+      & > .global-graph-container {
+        border: 1px solid var(--background-modifier-border-hover, var(--color-base-35));
+        background-color: var(--background-primary);
+      }
+    }
+  }
+
+  hr {
+    border: none;
+    border-top: var(--hr-thickness, 2px) solid;
+    border-color: var(--hr-color, var(--background-modifier-border, var(--lightgray)));
+  }
+
+  details.toc {
+    & summary {
+      cursor: pointer;
+
+      &::marker {
+        color: var(--text-muted);
+      }
+    }
+  }
+
+  .popover {
+    border: unset;
+
+    background-color: var(--background-primary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    box-shadow: var(--shadow-s);
+    max-height: var(--popover-max-height);
+    position: absolute;
+    z-index: var(--layer-popover);
+    display: none;
+
+    display: block;
+    position: fixed;
+    z-index: 999;
+
+    & .popover-inner {
+      border: 1px solid var(--background-modifier-border);
+
+      background-color: var(--background-primary);
+
+      border-radius: var(--radius-m);
+    }
+  }
+
+  .page > #quartz-body {
+    .center,
+    footer {
+      min-width: calc(100% - 2rem);
+      max-width: calc(100% - 2rem);
+      padding-left: 1rem;
+      padding-right: 1rem;
+    }
+    @media all and not ($desktop) {
+      .center,
+      .sidebar.right,
+      footer {
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+    }
+    @media all and ($mobile) {
+      .sidebar.left {
+        padding-left: 1rem;
+      }
+      .explorer:not(.collapsed) > .explorer-content {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        > .overflow {
+          overflow-x: hidden;
+        }
+      }
+    }
+  }
+
+  .page article p > strong,
+  strong {
+    color: var(--bold-color);
+    font-weight: var(--bold-weight);
+  }
+  .page article p > i,
+  .page article p > em,
+  i,
+  em {
+    color: var(--italic-color);
+    font-style: italic;
+  }
+  .page article p,
+  .page article ul,
+  .page article text,
+  .page article tr,
+  .page article td,
+  .page article li,
+  .page article ol,
+  .page article ul,
+  .page article .katex,
+  .page article .math,
+  p,
+  ul,
+  text,
+  tr,
+  td,
+  li,
+  ol,
+  ul,
+  .katex,
+  .math {
+    color: var(--text-normal);
+    font-family: var(--font-text, var(--font-default));
+    hyphens: none;
+  }
+  .page article a,
+  a {
+    font-family: var(--font-text, var(--font-default));
+    hyphens: none;
+  }
+
+  & {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+}
+:root[saved-theme="light"] {
+  button.darkmode {
+    mask-image: var(--sun-icon);
+    -webkit-mask-image: var(--sun-icon);
+  }
+}
+:root[saved-theme="dark"] {
+  button.darkmode {
+    mask-image: var(--moon-icon);
+    -webkit-mask-image: var(--moon-icon);
+  }
+}
+:root:root:root {
+  --bodyFont: var(--font-default) !important;
+  --codeFont: var(--font-monospace, var(--font-default)) !important;
+}
+:root:root[saved-theme="light"] {
+  --highlight-fallback: 258, 88%, 66%;
+  --lightgray: var(
+    --graph-line,
+    var(
+      --color-base-35,
+      var(
+        --background-modifier-border-focus,
+        var(--background-modifier-border, var(--color-base-30, #e0e0e0))
+      )
+    )
+  ) !important;
+  --darkgray: var(
+    --graph-node-unresolved,
+    var(--text-faint, var(--text-normal, var(--color-base-100, #222222)))
+  ) !important;
+  --tertiary: var(
+    --graph-node-tag,
+    var(
+      --color-green,
+      var(--link-color-hover, var(--text-accent-hover, var(--color-accent-2, #a386f9)))
+    )
+  ) !important;
+}
+:root:root[saved-theme="dark"] {
+  --highlight-fallback: 258, 88%, 66%;
+  --lightgray: var(
+    --graph-line,
+    var(
+      --color-base-35,
+      var(
+        --background-modifier-border-focus,
+        var(--background-modifier-border, var(--color-base-30, #363636))
+      )
+    )
+  ) !important;
+  --darkgray: var(
+    --graph-node-unresolved,
+    var(--text-faint, var(--text-normal, var(--color-base-100, #dadada)))
+  ) !important;
+  --tertiary: var(
+    --graph-node-tag,
+    var(
+      --color-green,
+      var(--link-color-hover, var(--text-accent-hover, var(--color-accent-2, #c5b6fc)))
+    )
+  ) !important;
+}


### PR DESCRIPTION
## Summary
- apply the Obsidian Gruvbox color palette to both dark and light modes with matching CSS variables and callout styling
- import the theme's typography stack and update global UI details such as navigation, search, and code blocks for a cohesive look
- inline the external-link icon asset to prevent missing files while keeping link treatments consistent with the palette

## Testing
- CI=1 npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8589990488327807a052b39033330