### PR TITLE
Polish Gruvbox theme and stabilize comments

### DIFF
--- a/quartz/components/scripts/comments.inline.ts
+++ b/quartz/components/scripts/comments.inline.ts
@@ -1,5 +1,6 @@
 const changeTheme = (e: CustomEventMap["themechange"]) => {
   const theme = e.detail.theme
+  const container = document.querySelector(".giscus") as GiscusElement | null
   const iframe = document.querySelector("iframe.giscus-frame") as HTMLIFrameElement
   if (!iframe) {
     return
@@ -9,11 +10,16 @@ const changeTheme = (e: CustomEventMap["themechange"]) => {
     return
   }
 
+  const resolvedTheme = getThemeName(theme)
+  if (container) {
+    container.setAttribute("data-theme", resolvedTheme)
+  }
+
   iframe.contentWindow.postMessage(
     {
       giscus: {
         setConfig: {
-          theme: getThemeUrl(getThemeName(theme)),
+          theme: getThemeUrl(resolvedTheme),
         },
       },
     },
@@ -82,9 +88,19 @@ document.addEventListener("nav", () => {
   giscusScript.setAttribute("data-lang", giscusContainer.dataset.lang)
   const storedTheme = localStorage.getItem("theme")
   const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches
-  const theme = storedTheme ?? (prefersLight ? "light" : "dark")
-  giscusContainer.setAttribute("data-theme", theme)
-  giscusScript.setAttribute("data-theme", getThemeUrl(getThemeName(theme)))
+  const savedTheme = document.documentElement.getAttribute("saved-theme")
+  const isBinaryTheme = (value: string | null): value is "light" | "dark" =>
+    value === "light" || value === "dark"
+  const theme = isBinaryTheme(savedTheme)
+    ? savedTheme
+    : isBinaryTheme(storedTheme)
+      ? storedTheme
+      : prefersLight
+        ? "light"
+        : "dark"
+  const resolvedTheme = getThemeName(theme)
+  giscusContainer.setAttribute("data-theme", resolvedTheme)
+  giscusScript.setAttribute("data-theme", getThemeUrl(resolvedTheme))
 
   giscusContainer.appendChild(giscusScript)
 

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -1,9 +1,9 @@
-import FlexSearch from "flexsearch"
+import { Document as FlexSearchDocument, DocumentData } from "flexsearch"
 import { ContentDetails } from "../../plugins/emitters/contentIndex"
 import { registerEscapeHandler, removeAllChildren } from "./util"
 import { FullSlug, normalizeRelativeURLs, resolveRelative } from "../../util/path"
 
-interface Item {
+interface Item extends DocumentData {
   id: number
   slug: FullSlug
   title: string
@@ -16,8 +16,7 @@ type SearchType = "basic" | "tags"
 let searchType: SearchType = "basic"
 let currentSearchTerm: string = ""
 const encoder = (str: string) => str.toLowerCase().split(/([^a-z]|[^\x00-\x7F])/)
-let index = new FlexSearch.Document<Item>({
-  charset: "latin:extra",
+let index: FlexSearchDocument<Item> = new FlexSearchDocument<Item>({
   encode: encoder,
   document: {
     id: "id",
@@ -38,6 +37,8 @@ let index = new FlexSearch.Document<Item>({
     ],
   },
 })
+
+type SearchResults = Array<{ field: string; result: number[] }>
 
 const p = new DOMParser()
 const fetchContentCache: Map<FullSlug, Element[]> = new Map()
@@ -397,7 +398,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     searchLayout.classList.toggle("display-results", currentSearchTerm !== "")
     searchType = currentSearchTerm.startsWith("#") ? "tags" : "basic"
 
-    let searchResults: FlexSearch.SimpleDocumentSearchResultSetUnit[]
+    let searchResults: SearchResults
     if (searchType === "tags") {
       currentSearchTerm = currentSearchTerm.substring(1).trim()
       const separatorIndex = currentSearchTerm.indexOf(" ")
@@ -405,13 +406,13 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         // search by title and content index and then filter by tag (implemented in flexsearch)
         const tag = currentSearchTerm.substring(0, separatorIndex)
         const query = currentSearchTerm.substring(separatorIndex + 1).trim()
-        searchResults = await index.searchAsync({
+        searchResults = (await index.searchAsync({
           query: query,
           // return at least 10000 documents, so it is enough to filter them by tag (implemented in flexsearch)
           limit: Math.max(numSearchResults, 10000),
           index: ["title", "content"],
-          tag: tag,
-        })
+          tag: [{ tags: tag }],
+        })) as SearchResults
         for (let searchResult of searchResults) {
           searchResult.result = searchResult.result.slice(0, numSearchResults)
         }
@@ -420,18 +421,18 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         currentSearchTerm = query
       } else {
         // default search by tags index
-        searchResults = await index.searchAsync({
+        searchResults = (await index.searchAsync({
           query: currentSearchTerm,
           limit: numSearchResults,
           index: ["tags"],
-        })
+        })) as SearchResults
       }
     } else if (searchType === "basic") {
-      searchResults = await index.searchAsync({
+      searchResults = (await index.searchAsync({
         query: currentSearchTerm,
         limit: numSearchResults,
         index: ["title", "content"],
-      })
+      })) as SearchResults
     }
 
     const getByField = (field: string): number[] => {

--- a/quartz/static/giscus/dark.css
+++ b/quartz/static/giscus/dark.css
@@ -4,96 +4,134 @@
  */
 
 main {
-  --color-prettylights-syntax-comment: #8b949e;
-  --color-prettylights-syntax-constant: #79c0ff;
-  --color-prettylights-syntax-entity: #d2a8ff;
-  --color-prettylights-syntax-storage-modifier-import: #c9d1d9;
-  --color-prettylights-syntax-entity-tag: #7ee787;
-  --color-prettylights-syntax-keyword: #ff7b72;
-  --color-prettylights-syntax-string: #a5d6ff;
-  --color-prettylights-syntax-variable: #ffa657;
-  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
-  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
-  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
-  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
-  --color-prettylights-syntax-carriage-return-bg: #b62324;
-  --color-prettylights-syntax-string-regexp: #7ee787;
-  --color-prettylights-syntax-markup-list: #f2cc60;
-  --color-prettylights-syntax-markup-heading: #1f6feb;
-  --color-prettylights-syntax-markup-italic: #c9d1d9;
-  --color-prettylights-syntax-markup-bold: #c9d1d9;
-  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
-  --color-prettylights-syntax-markup-deleted-bg: #67060c;
-  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
-  --color-prettylights-syntax-markup-inserted-bg: #033a16;
-  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
-  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
-  --color-prettylights-syntax-markup-ignored-text: #c9d1d9;
-  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
-  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
-  --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
-  --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
-  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-  --color-btn-text: #e0e0e0; /* --darkgray */
-  --color-btn-bg: #1a1a1a; /* --light */
-  --color-btn-border: rgb(255 255 255 / 10%); /* --dark */
-  --color-btn-shadow: 0 0 transparent;
-  --color-btn-inset-shadow: 0 0 transparent;
-  --color-btn-hover-bg: #2d2d2d; /* --lightgray */
-  --color-btn-hover-border: #e0e0e0; /* --darkgray */
-  --color-btn-active-bg: #262626;
-  --color-btn-active-border: #cfcfcf;
-  --color-btn-selected-bg: #2d2d2d; /* --lightgray */
-  --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #ffa726; /* --tertiary */
-  --color-btn-primary-border: rgb(255 255 255 / 10%); /* --dark */
-  --color-btn-primary-shadow: 0 0 transparent;
-  --color-btn-primary-inset-shadow: 0 0 transparent;
-  --color-btn-primary-hover-bg: #ff6b6b; /* --secondary */
-  --color-btn-primary-hover-border: rgb(255 255 255 / 10%); /* --dark */
-  --color-btn-primary-selected-bg: #ff6b6b; /* --secondary */
-  --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 25%);
-  --color-btn-primary-disabled-text: rgba(255, 255, 255, 0.5);
-  --color-btn-primary-disabled-bg: rgba(255, 167, 38, 0.35);
-  --color-btn-primary-disabled-border: rgb(255 255 255 / 10%);
-  --color-action-list-item-default-hover-bg: rgb(64 64 64 / 40%);
-  --color-segmented-control-bg: rgb(64 64 64 / 40%);
-  --color-segmented-control-button-bg: #1a1a1a;
-  --color-segmented-control-button-selected-border: #e0e0e0;
-  --color-fg-default: #ffffff; /* --dark */
-  --color-fg-muted: #e0e0e0; /* --darkgray */
-  --color-fg-subtle: #e0e0e0; /* --darkgray */
-  --color-canvas-default: #1a1a1a; /* --light */
-  --color-canvas-overlay: #2d2d2d; /* --lightgray */
-  --color-canvas-inset: #121212;
-  --color-canvas-subtle: #2d2d2d; /* --lightgray */
-  --color-border-default: #404040; /* --gray */
-  --color-border-muted: #2d2d2d; /* --lightgray */
-  --color-neutral-muted: rgb(224 224 224 / 16%);
-  --color-accent-fg: #ff6b6b; /* --secondary */
-  --color-accent-emphasis: #ff6b6b; /* --secondary */
-  --color-accent-muted: rgb(255 107 107 / 40%);
-  --color-accent-subtle: rgba(255, 107, 107, 0.15);
-  --color-success-fg: #3fb950;
-  --color-attention-fg: #ffa726; /* --tertiary */
-  --color-attention-muted: rgb(255 167 38 / 40%);
-  --color-attention-subtle: rgba(255, 167, 38, 0.2);
-  --color-danger-fg: #ff6b6b; /* --secondary */
-  --color-danger-muted: rgb(255 107 107 / 40%);
-  --color-danger-subtle: rgba(255, 107, 107, 0.15);
-  --color-primer-shadow-inset: 0 0 transparent;
-  --color-scale-gray-7: #2d2d2d;
-  --color-scale-blue-8: #4a1f17;
+  color-scheme: dark;
+  font-family:
+    "Inter",
+    "Avenir",
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  background-color: #282828;
 
-  /*! Extensions from @primer/css/alerts/flash.scss */
-  --color-social-reaction-bg-hover: var(--color-scale-gray-7);
-  --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-8);
+  --color-prettylights-syntax-comment: #928374;
+  --color-prettylights-syntax-constant: #83a598;
+  --color-prettylights-syntax-entity: #d3869b;
+  --color-prettylights-syntax-storage-modifier-import: #ebdbb2;
+  --color-prettylights-syntax-entity-tag: #8ec07c;
+  --color-prettylights-syntax-keyword: #fb4934;
+  --color-prettylights-syntax-string: #b8bb26;
+  --color-prettylights-syntax-variable: #fe8019;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #fb4934;
+  --color-prettylights-syntax-invalid-illegal-text: #282828;
+  --color-prettylights-syntax-invalid-illegal-bg: #fb4934;
+  --color-prettylights-syntax-carriage-return-text: #282828;
+  --color-prettylights-syntax-carriage-return-bg: #fb4934;
+  --color-prettylights-syntax-string-regexp: #8ec07c;
+  --color-prettylights-syntax-markup-list: #fabd2f;
+  --color-prettylights-syntax-markup-heading: #83a598;
+  --color-prettylights-syntax-markup-italic: #ebdbb2;
+  --color-prettylights-syntax-markup-bold: #ebdbb2;
+  --color-prettylights-syntax-markup-deleted-text: #fb4934;
+  --color-prettylights-syntax-markup-deleted-bg: #3c3836;
+  --color-prettylights-syntax-markup-inserted-text: #b8bb26;
+  --color-prettylights-syntax-markup-inserted-bg: #32361a;
+  --color-prettylights-syntax-markup-changed-text: #fabd2f;
+  --color-prettylights-syntax-markup-changed-bg: #613e16;
+  --color-prettylights-syntax-markup-ignored-text: #d5c4a1;
+  --color-prettylights-syntax-markup-ignored-bg: #3b4244;
+  --color-prettylights-syntax-meta-diff-range: #d3869b;
+  --color-prettylights-syntax-brackethighlighter-angle: #928374;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #504945;
+  --color-prettylights-syntax-constant-other-reference-link: #83a598;
+
+  --color-btn-text: #ebdbb2;
+  --color-btn-bg: #282828;
+  --color-btn-border: #3c3836;
+  --color-btn-shadow: none;
+  --color-btn-inset-shadow: none;
+  --color-btn-hover-bg: #3c3836;
+  --color-btn-hover-border: #ebdbb2;
+  --color-btn-active-bg: #504945;
+  --color-btn-active-border: #ebdbb2;
+  --color-btn-selected-bg: #3c3836;
+  --color-btn-primary-text: #1d2021;
+  --color-btn-primary-bg: #fe8019;
+  --color-btn-primary-border: #fe8019;
+  --color-btn-primary-shadow: none;
+  --color-btn-primary-inset-shadow: none;
+  --color-btn-primary-hover-bg: #fabd2f;
+  --color-btn-primary-hover-border: #fabd2f;
+  --color-btn-primary-selected-bg: #fe8019;
+  --color-btn-primary-selected-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.25);
+  --color-btn-primary-disabled-text: rgba(29, 32, 33, 0.6);
+  --color-btn-primary-disabled-bg: rgba(254, 128, 25, 0.35);
+  --color-btn-primary-disabled-border: rgba(254, 128, 25, 0.35);
+  --color-action-list-item-default-hover-bg: rgba(188, 188, 188, 0.08);
+  --color-segmented-control-bg: rgba(236, 229, 206, 0.08);
+  --color-segmented-control-button-bg: #282828;
+  --color-segmented-control-button-selected-border: #ebdbb2;
+
+  --color-fg-default: #ebdbb2;
+  --color-fg-muted: #d5c4a1;
+  --color-fg-subtle: #bdae93;
+  --color-canvas-default: #282828;
+  --color-canvas-overlay: #32302f;
+  --color-canvas-inset: #1d2021;
+  --color-canvas-subtle: #3c3836;
+  --color-border-default: #504945;
+  --color-border-muted: #3c3836;
+  --color-neutral-muted: rgba(214, 199, 168, 0.16);
+  --color-accent-fg: #fe8019;
+  --color-accent-emphasis: #fe8019;
+  --color-accent-muted: rgba(254, 128, 25, 0.4);
+  --color-accent-subtle: rgba(254, 128, 25, 0.15);
+  --color-success-fg: #8ec07c;
+  --color-attention-fg: #fabd2f;
+  --color-attention-muted: rgba(250, 189, 47, 0.35);
+  --color-attention-subtle: rgba(250, 189, 47, 0.15);
+  --color-danger-fg: #fb4934;
+  --color-danger-muted: rgba(251, 73, 52, 0.4);
+  --color-danger-subtle: rgba(251, 73, 52, 0.18);
+  --color-primer-shadow-inset: none;
+  --color-scale-gray-7: #3c3836;
+  --color-scale-blue-8: #1d2021;
 }
 
-main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line-dark.svg");
+main,
+main * {
+  animation: none !important;
+  transition: none !important;
 }
 
+main .pagination-loader-container,
 main .gsc-loading-image {
-  background-image: url("https://github.githubassets.com/images/mona-loading-dark.gif");
+  display: none !important;
+}
+
+main .gsc-comment-box textarea,
+main .gsc-comment-box textarea::placeholder {
+  color: inherit;
+}
+
+main .gsc-comment-box textarea {
+  background-color: #32302f;
+  border-color: #504945;
+}
+
+main .gsc-input input {
+  background-color: #32302f;
+  border-color: #504945;
+  color: inherit;
+}
+
+main .gsc-reactions button {
+  border-color: #504945;
+}
+
+main .gsc-timeline {
+  background-color: transparent;
 }

--- a/quartz/static/giscus/light.css
+++ b/quartz/static/giscus/light.css
@@ -4,96 +4,134 @@
  */
 
 main {
-  --color-prettylights-syntax-comment: #6e7781;
-  --color-prettylights-syntax-constant: #0550ae;
-  --color-prettylights-syntax-entity: #8250df;
-  --color-prettylights-syntax-storage-modifier-import: #24292f;
-  --color-prettylights-syntax-entity-tag: #116329;
-  --color-prettylights-syntax-keyword: #cf222e;
-  --color-prettylights-syntax-string: #0a3069;
-  --color-prettylights-syntax-variable: #953800;
-  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
-  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
-  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
-  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
-  --color-prettylights-syntax-carriage-return-bg: #cf222e;
-  --color-prettylights-syntax-string-regexp: #116329;
-  --color-prettylights-syntax-markup-list: #3b2300;
-  --color-prettylights-syntax-markup-heading: #0550ae;
-  --color-prettylights-syntax-markup-italic: #24292f;
-  --color-prettylights-syntax-markup-bold: #24292f;
-  --color-prettylights-syntax-markup-deleted-text: #82071e;
-  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
-  --color-prettylights-syntax-markup-inserted-text: #116329;
-  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
-  --color-prettylights-syntax-markup-changed-text: #953800;
-  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
-  --color-prettylights-syntax-markup-ignored-text: #eaeef2;
-  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
-  --color-prettylights-syntax-meta-diff-range: #8250df;
-  --color-prettylights-syntax-brackethighlighter-angle: #57606a;
-  --color-prettylights-syntax-sublimelinter-gutter-mark: #8c959f;
-  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
-  --color-btn-text: #666666; /* --darkgray */
-  --color-btn-bg: #ffffff; /* --light */
-  --color-btn-border: rgb(51 51 51 / 15%); /* --dark */
-  --color-btn-shadow: 0 1px 0 rgb(51 51 51 / 4%);
-  --color-btn-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 25%);
-  --color-btn-hover-bg: #f5f5f5; /* --lightgray */
-  --color-btn-hover-border: rgb(51 51 51 / 15%); /* --dark */
-  --color-btn-active-bg: #f0f0f0;
-  --color-btn-active-border: rgb(51 51 51 / 15%);
-  --color-btn-selected-bg: #f5f5f5; /* --lightgray */
-  --color-btn-primary-text: #fff;
-  --color-btn-primary-bg: #ffa726; /* --tertiary */
-  --color-btn-primary-border: rgb(51 51 51 / 15%); /* --dark */
-  --color-btn-primary-shadow: 0 1px 0 rgb(51 51 51 / 10%);
-  --color-btn-primary-inset-shadow: inset 0 1px 0 rgb(255 255 255 / 6%);
-  --color-btn-primary-hover-bg: #ff6b6b; /* --secondary */
-  --color-btn-primary-hover-border: rgb(51 51 51 / 15%); /* --dark */
-  --color-btn-primary-selected-bg: #ff6b6b; /* --secondary */
-  --color-btn-primary-selected-shadow: inset 0 1px 0 rgb(0 0 0 / 12%);
-  --color-btn-primary-disabled-text: rgb(255 255 255 / 80%);
-  --color-btn-primary-disabled-bg: rgba(255, 167, 38, 0.45);
-  --color-btn-primary-disabled-border: rgb(51 51 51 / 15%);
-  --color-action-list-item-default-hover-bg: rgb(208 215 222 / 32%);
-  --color-segmented-control-bg: #f5f5f5;
-  --color-segmented-control-button-bg: #fff;
-  --color-segmented-control-button-selected-border: #d0d0d0;
-  --color-fg-default: #333333; /* --dark */
-  --color-fg-muted: #666666; /* --darkgray */
-  --color-fg-subtle: #666666; /* --darkgray */
-  --color-canvas-default: #ffffff; /* --light */
-  --color-canvas-overlay: #ffffff;
-  --color-canvas-inset: #f5f5f5; /* --lightgray */
-  --color-canvas-subtle: #f5f5f5; /* --lightgray */
-  --color-border-default: #d0d0d0; /* --gray */
-  --color-border-muted: #e6e6e6;
-  --color-neutral-muted: rgb(102 102 102 / 20%);
-  --color-accent-fg: #ff6b6b; /* --secondary */
-  --color-accent-emphasis: #ff6b6b; /* --secondary */
-  --color-accent-muted: rgb(255 107 107 / 40%);
-  --color-accent-subtle: rgba(255, 107, 107, 0.15);
-  --color-success-fg: #1a7f37;
-  --color-attention-fg: #ffa726; /* --tertiary */
-  --color-attention-muted: rgb(255 167 38 / 40%);
-  --color-attention-subtle: rgba(255, 167, 38, 0.2);
-  --color-danger-fg: #ff6b6b; /* --secondary */
-  --color-danger-muted: rgb(255 107 107 / 40%);
-  --color-danger-subtle: rgba(255, 107, 107, 0.15);
-  --color-primer-shadow-inset: inset 0 1px 0 rgb(208 215 222 / 20%);
-  --color-scale-gray-1: #f5f5f5;
-  --color-scale-blue-1: #fff3cd; /* --textHighlight */
+  color-scheme: light;
+  font-family:
+    "Inter",
+    "Avenir",
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
+  background-color: #fbf1c7;
 
-  /*! Extensions from @primer/css/alerts/flash.scss */
-  --color-social-reaction-bg-hover: var(--color-scale-gray-1);
-  --color-social-reaction-bg-reacted-hover: var(--color-scale-blue-1);
+  --color-prettylights-syntax-comment: #928374;
+  --color-prettylights-syntax-constant: #076678;
+  --color-prettylights-syntax-entity: #b16286;
+  --color-prettylights-syntax-storage-modifier-import: #3c3836;
+  --color-prettylights-syntax-entity-tag: #689d6a;
+  --color-prettylights-syntax-keyword: #cc241d;
+  --color-prettylights-syntax-string: #98971a;
+  --color-prettylights-syntax-variable: #d65d0e;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #cc241d;
+  --color-prettylights-syntax-invalid-illegal-text: #fbf1c7;
+  --color-prettylights-syntax-invalid-illegal-bg: #cc241d;
+  --color-prettylights-syntax-carriage-return-text: #fbf1c7;
+  --color-prettylights-syntax-carriage-return-bg: #cc241d;
+  --color-prettylights-syntax-string-regexp: #689d6a;
+  --color-prettylights-syntax-markup-list: #d79921;
+  --color-prettylights-syntax-markup-heading: #458588;
+  --color-prettylights-syntax-markup-italic: #3c3836;
+  --color-prettylights-syntax-markup-bold: #3c3836;
+  --color-prettylights-syntax-markup-deleted-text: #9d0006;
+  --color-prettylights-syntax-markup-deleted-bg: #f2c9c0;
+  --color-prettylights-syntax-markup-inserted-text: #79740e;
+  --color-prettylights-syntax-markup-inserted-bg: #f0f4c4;
+  --color-prettylights-syntax-markup-changed-text: #d79921;
+  --color-prettylights-syntax-markup-changed-bg: #f6e1bb;
+  --color-prettylights-syntax-markup-ignored-text: #665c54;
+  --color-prettylights-syntax-markup-ignored-bg: #d3d7cf;
+  --color-prettylights-syntax-meta-diff-range: #b16286;
+  --color-prettylights-syntax-brackethighlighter-angle: #928374;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #d5c4a1;
+  --color-prettylights-syntax-constant-other-reference-link: #076678;
+
+  --color-btn-text: #3c3836;
+  --color-btn-bg: #fbf1c7;
+  --color-btn-border: #d5c4a1;
+  --color-btn-shadow: none;
+  --color-btn-inset-shadow: none;
+  --color-btn-hover-bg: #ebdbb2;
+  --color-btn-hover-border: #3c3836;
+  --color-btn-active-bg: #d5c4a1;
+  --color-btn-active-border: #3c3836;
+  --color-btn-selected-bg: #ebdbb2;
+  --color-btn-primary-text: #fbf1c7;
+  --color-btn-primary-bg: #d65d0e;
+  --color-btn-primary-border: #d65d0e;
+  --color-btn-primary-shadow: none;
+  --color-btn-primary-inset-shadow: none;
+  --color-btn-primary-hover-bg: #cc241d;
+  --color-btn-primary-hover-border: #cc241d;
+  --color-btn-primary-selected-bg: #d65d0e;
+  --color-btn-primary-selected-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.08);
+  --color-btn-primary-disabled-text: rgba(251, 241, 199, 0.7);
+  --color-btn-primary-disabled-bg: rgba(214, 93, 14, 0.35);
+  --color-btn-primary-disabled-border: rgba(214, 93, 14, 0.35);
+  --color-action-list-item-default-hover-bg: rgba(146, 131, 116, 0.16);
+  --color-segmented-control-bg: rgba(235, 219, 178, 0.65);
+  --color-segmented-control-button-bg: #fbf1c7;
+  --color-segmented-control-button-selected-border: #3c3836;
+
+  --color-fg-default: #3c3836;
+  --color-fg-muted: #504945;
+  --color-fg-subtle: #665c54;
+  --color-canvas-default: #fbf1c7;
+  --color-canvas-overlay: #f2e5bc;
+  --color-canvas-inset: #f9f5d7;
+  --color-canvas-subtle: #ebdbb2;
+  --color-border-default: #d5c4a1;
+  --color-border-muted: #ebdbb2;
+  --color-neutral-muted: rgba(146, 131, 116, 0.22);
+  --color-accent-fg: #d65d0e;
+  --color-accent-emphasis: #d65d0e;
+  --color-accent-muted: rgba(214, 93, 14, 0.4);
+  --color-accent-subtle: rgba(214, 93, 14, 0.18);
+  --color-success-fg: #79740e;
+  --color-attention-fg: #d79921;
+  --color-attention-muted: rgba(215, 153, 33, 0.4);
+  --color-attention-subtle: rgba(215, 153, 33, 0.18);
+  --color-danger-fg: #cc241d;
+  --color-danger-muted: rgba(204, 36, 29, 0.38);
+  --color-danger-subtle: rgba(204, 36, 29, 0.18);
+  --color-primer-shadow-inset: none;
+  --color-scale-gray-7: #ebdbb2;
+  --color-scale-blue-8: #e0cfa9;
 }
 
-main .pagination-loader-container {
-  background-image: url("https://github.com/images/modules/pulls/progressive-disclosure-line.svg");
+main,
+main * {
+  animation: none !important;
+  transition: none !important;
 }
 
+main .pagination-loader-container,
 main .gsc-loading-image {
-  background-image: url("https://github.githubassets.com/images/mona-loading-default.gif");
+  display: none !important;
+}
+
+main .gsc-comment-box textarea,
+main .gsc-comment-box textarea::placeholder {
+  color: inherit;
+}
+
+main .gsc-comment-box textarea {
+  background-color: #f2e5bc;
+  border-color: #d5c4a1;
+}
+
+main .gsc-input input {
+  background-color: #f2e5bc;
+  border-color: #d5c4a1;
+  color: inherit;
+}
+
+main .gsc-reactions button {
+  border-color: #d5c4a1;
+}
+
+main .gsc-timeline {
+  background-color: transparent;
 }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1,303 +1,362 @@
 @use "./base.scss";
 
-// Gruvbox Text Colors Only
-// =========================
+// Gruvbox-inspired theme variables
+:root {
+  --bodyFont:
+    "Inter", "Avenir", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+    Arial, sans-serif;
+  --headerFont:
+    "Avenir", "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+    Arial, sans-serif;
+  --codeFont:
+    "Source Code Pro", "Fira Code", "SFMono-Regular", Menlo, Monaco, "Courier New", monospace;
 
-// Heading colors from Gruvbox
-h1,
+  --callout-border-width: 1px;
+  --callout-border-opacity: 0.28;
+  --callout-default: 69, 133, 136;
+  --callout-summary: 104, 157, 106;
+  --callout-info: 69, 133, 136;
+  --callout-todo: 69, 133, 136;
+  --callout-important: 215, 153, 33;
+  --callout-tip: 142, 192, 124;
+  --callout-success: 152, 151, 26;
+  --callout-question: 215, 153, 33;
+  --callout-warning: 214, 93, 14;
+  --callout-fail: 204, 36, 29;
+  --callout-error: 204, 36, 29;
+  --callout-bug: 204, 36, 29;
+  --callout-example: 177, 98, 134;
+  --callout-quote: 146, 131, 116;
+
+  --heading-1: #cc241d;
+  --heading-2: #d79921;
+  --heading-3: #98971a;
+  --heading-4: #689d6a;
+  --heading-5: #458588;
+  --heading-6: #b16286;
+
+  --link-color: #d65d0e;
+  --link-hover: #8ec07c;
+  --link-muted: #928374;
+
+  --inline-code-bg: #f2e5bc;
+  --inline-code-text: #3c3836;
+  --block-code-bg: #ebdbb2;
+  --block-code-text: #3c3836;
+  --blockquote-border: #928374;
+  --blockquote-bg: rgba(146, 131, 116, 0.18);
+  --table-stripe: rgba(146, 131, 116, 0.1);
+}
+
+:root[saved-theme="light"] {
+  color-scheme: light;
+
+  --light: #fbf1c7;
+  --lightgray: #e0cfa9;
+  --gray: #d5c4a1;
+  --darkgray: #3c3836;
+  --dark: #1d2021;
+  --secondary: #cc241d;
+  --tertiary: #98971a;
+  --highlight: rgba(204, 36, 29, 0.18);
+  --textHighlight: rgba(250, 189, 47, 0.35);
+
+  --inline-code-bg: #f2e5bc;
+  --inline-code-text: #3c3836;
+  --block-code-bg: #ebdbb2;
+  --block-code-text: #3c3836;
+  --blockquote-bg: rgba(235, 219, 178, 0.55);
+  --table-stripe: rgba(235, 219, 178, 0.6);
+}
+
+:root[saved-theme="dark"] {
+  color-scheme: dark;
+
+  --light: #1d2021;
+  --lightgray: #3c3836;
+  --gray: #928374;
+  --darkgray: #ebdbb2;
+  --dark: #fbf1c7;
+  --secondary: #fe8019;
+  --tertiary: #b8bb26;
+  --highlight: rgba(254, 128, 25, 0.22);
+  --textHighlight: rgba(250, 189, 47, 0.35);
+
+  --inline-code-bg: #32302f;
+  --inline-code-text: #ebdbb2;
+  --block-code-bg: #282828;
+  --block-code-text: #ebdbb2;
+  --blockquote-bg: rgba(40, 40, 40, 0.72);
+  --table-stripe: rgba(60, 56, 54, 0.55);
+}
+
+body {
+  background-color: var(--light);
+  color: var(--darkgray);
+  font-family: var(--bodyFont);
+  line-height: 1.6;
+}
+
 .page-title,
-.article-title,
-header h1,
-.page article h1 {
-  color: #cc241d !important; /* Gruvbox red */
+.page-title a,
+.page article h1,
+.page article h1 a,
+header h1 {
+  color: var(--heading-1);
 }
 
-h2,
-header h2,
-.page article h2 {
-  color: #98971a !important; /* Gruvbox green */
+.page article h2,
+.page article h2 a,
+header h2 {
+  color: var(--heading-2);
 }
 
-h3,
-header h3,
-.page article h3 {
-  color: #d79921 !important; /* Gruvbox yellow */
+.page article h3,
+.page article h3 a,
+header h3 {
+  color: var(--heading-3);
 }
 
-h4,
-.page article h4 {
-  color: #458588 !important; /* Gruvbox aqua */
+.page article h4,
+header h4 {
+  color: var(--heading-4);
 }
 
-h5,
-.page article h5 {
-  color: #b16286 !important; /* Gruvbox purple */
+.page article h5,
+header h5 {
+  color: var(--heading-5);
 }
 
-h6,
-.page article h6 {
-  color: #689d6a !important; /* Gruvbox aqua */
+.page article h6,
+header h6 {
+  color: var(--heading-6);
 }
 
-// Gruvbox text emphasis and styling - only for regular content, not callouts
-.page article strong:not(.callout strong),
-.page article p > strong:not(.callout strong) {
-  color: #d79921 !important; /* Gruvbox yellow */
-  font-weight: 600 !important;
+.page article strong,
+.page article p > strong {
+  color: var(--heading-2);
+  font-weight: 600;
 }
 
-.page article em:not(.callout em),
-.page article i:not(.callout i),
-.page article p > em:not(.callout em),
-.page article p > i:not(.callout i) {
-  color: #d79921 !important; /* Gruvbox yellow */
-  font-style: italic !important;
+.page article em,
+.page article i,
+.page article p > em,
+.page article p > i {
+  color: var(--heading-2);
+  font-style: italic;
 }
 
-// Links with Gruvbox colors
 a,
 a.internal,
 a.external,
 .page article a {
-  color: #cc241d !important; /* Gruvbox red */
-  text-decoration: none !important;
+  color: var(--link-color);
+  text-decoration: none;
+  transition:
+    color 0.2s ease,
+    opacity 0.2s ease;
 }
 
 a:hover,
 a.internal:hover,
-a.external:hover {
-  color: #98971a !important; /* Gruvbox green */
+a.external:hover,
+.page article a:hover {
+  color: var(--link-hover);
 }
 
-// Code styling with Gruvbox - only for regular content, not callouts
-.page article code:not(pre code):not(.callout code) {
-  background-color: #ebdbb2 !important; /* Gruvbox light1 */
-  color: #458588 !important; /* Gruvbox blue */
-  padding: 0.1em 0.3em !important;
-  border-radius: 3px !important;
-  font-family: var(--codeFont) !important;
+a.internal.broken {
+  color: var(--link-muted);
 }
 
-.page article pre:not(.callout pre) {
-  background-color: #ebdbb2 !important; /* Gruvbox light1 */
-  color: #3c3836 !important; /* Gruvbox dark1 */
-  border-radius: 4px !important;
-  padding: 1rem !important;
-  font-family: var(--codeFont) !important;
+.page article code:not(pre code) {
+  background-color: var(--inline-code-bg);
+  color: var(--inline-code-text);
+  border-radius: 4px;
+  padding: 0.15em 0.35em;
+  font-family: var(--codeFont);
+  border: 1px solid color-mix(in srgb, var(--inline-code-bg) 70%, transparent);
 }
 
-// Blockquotes with simple gray styling - only for regular content, not callouts
+.page article pre {
+  background-color: var(--block-code-bg);
+  color: var(--block-code-text);
+  border-radius: 8px;
+  padding: 1rem;
+  font-family: var(--codeFont);
+  border: 1px solid color-mix(in srgb, var(--block-code-bg) 70%, transparent);
+  overflow-x: auto;
+}
+
+.page article pre code {
+  background: none;
+  color: inherit;
+  padding: 0;
+  border: none;
+}
+
 .page article blockquote:not(.callout) {
-  border-left: 3px solid #666 !important; /* Simple gray */
-  color: #333 !important; /* Dark gray text */
-  background-color: #f5f5f5 !important; /* Light gray background */
-  padding: 1rem 1.5rem !important;
-  margin: 1.5rem 0 !important;
-  font-style: italic !important;
-  border-radius: 4px !important;
+  border-left: 4px solid var(--blockquote-border);
+  background-color: var(--blockquote-bg);
+  color: var(--darkgray);
+  padding: 1rem 1.5rem;
+  margin: 1.5rem 0;
+  border-radius: 6px;
+  font-style: italic;
 }
 
-// Override the base blockquote styling to use gray instead of var(--secondary)
 blockquote {
-  border-left-color: #666 !important; /* Simple gray border instead of red */
-}
-
-// Colorful Callouts - Matching the Showcase Image
-// ===============================================
-
-// Color variables for callouts matching the image
-:root {
-  --callout-border-width: 1px;
-  --callout-border-opacity: 0.8;
-  --callout-default: 69, 133, 136; /* Blue for info */
-  --callout-summary: 104, 157, 106; /* Green for summary/abstract */
-  --callout-info: 69, 133, 136; /* Blue for info */
-  --callout-todo: 69, 133, 136; /* Blue for todo */
-  --callout-important: 104, 157, 106; /* Green for important */
-  --callout-tip: 104, 157, 106; /* Green for tip */
-  --callout-success: 104, 157, 106; /* Green for success */
-  --callout-question: 215, 153, 33; /* Yellow for question */
-  --callout-warning: 214, 93, 14; /* Orange for warning */
-  --callout-fail: 204, 36, 29; /* Red for failure */
-  --callout-error: 204, 36, 29; /* Red for error */
-  --callout-bug: 204, 36, 29; /* Red for bug */
-  --callout-example: 177, 98, 134; /* Purple for example */
-  --callout-quote: 146, 131, 116; /* Beige for quote */
+  border-left-color: var(--blockquote-border);
 }
 
 .callout {
-  --callout-color: var(--callout-default) !important;
-  overflow: hidden !important;
-  border-style: solid !important;
-  border-color: rgba(var(--callout-color), var(--callout-border-opacity)) !important;
-  border-width: var(--callout-border-width) !important;
-  border-radius: 4px !important;
-  margin: 1em 0 !important;
-  padding: 12px 12px 12px 24px !important;
-  background-color: rgba(var(--callout-color), 0.15) !important;
-
-  &[data-callout] {
-    --callout-color: var(--callout-default) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="abstract"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="summary"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="tldr"] {
-    --callout-color: var(--callout-summary) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="info"] {
-    --callout-color: var(--callout-info) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="todo"] {
-    --callout-color: var(--callout-todo) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="important"] {
-    --callout-color: var(--callout-important) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="tip"] {
-    --callout-color: var(--callout-tip) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="hint"] {
-    --callout-color: var(--callout-tip) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="success"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="check"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="done"] {
-    --callout-color: var(--callout-success) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="question"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="help"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="faq"] {
-    --callout-color: var(--callout-question) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="warning"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="caution"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="attention"] {
-    --callout-color: var(--callout-warning) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="failure"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="fail"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="missing"] {
-    --callout-color: var(--callout-fail) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="danger"] {
-    --callout-color: var(--callout-error) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="error"] {
-    --callout-color: var(--callout-error) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="bug"] {
-    --callout-color: var(--callout-bug) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="example"] {
-    --callout-color: var(--callout-example) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="quote"] {
-    --callout-color: var(--callout-quote) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
-  
-  &[data-callout="cite"] {
-    --callout-color: var(--callout-quote) !important;
-    background-color: rgba(var(--callout-color), 0.15) !important;
-  }
+  --callout-color: var(--callout-default);
+  border-style: solid;
+  border-color: rgba(var(--callout-color), var(--callout-border-opacity));
+  border-width: var(--callout-border-width);
+  border-radius: 6px;
+  background-color: rgba(var(--callout-color), 0.16);
+  padding: 0.9rem 1rem 0.9rem 1.2rem;
+  margin: 1.25rem 0;
+  overflow: hidden;
 }
 
 .callout-title {
-  padding: 0 !important;
-  display: flex !important;
-  gap: 4px !important;
-  font-size: inherit !important;
-  color: rgb(var(--callout-color)) !important;
-  line-height: 1.3 !important;
-  align-items: flex-start !important;
-  font-weight: 600 !important;
-  margin-bottom: 0.5rem !important;
-
-  & > .callout-title-inner > p {
-    font-weight: 600 !important;
-    color: inherit !important;
-  }
-
-  .callout-title-inner {
-    font-weight: 600 !important;
-    color: inherit !important;
-  }
+  color: rgb(var(--callout-color));
+  font-weight: 600;
+  margin-bottom: 0.4rem;
 }
 
 .callout-content {
-  overflow-x: auto;
-  padding: 0;
-  background-color: transparent;
+  background: transparent;
 }
 
-// put your custom CSS here!
+$callout-groups: (
+  summary: (
+    "abstract",
+    "summary",
+    "tldr",
+  ),
+  info: (
+    "info",
+    "todo",
+  ),
+  important: (
+    "important",
+  ),
+  tip: (
+    "tip",
+    "hint",
+  ),
+  success: (
+    "success",
+    "check",
+    "done",
+  ),
+  question: (
+    "question",
+    "help",
+    "faq",
+  ),
+  warning: (
+    "warning",
+    "caution",
+    "attention",
+  ),
+  fail: (
+    "failure",
+    "fail",
+    "missing",
+  ),
+  error: (
+    "danger",
+    "error",
+    "bug",
+  ),
+  example: (
+    "example",
+  ),
+  quote: (
+    "quote",
+    "cite",
+  ),
+);
+
+@each $group, $callouts in $callout-groups {
+  $color-var: var(--callout-#{$group});
+  .callout {
+    @each $callout in $callouts {
+      &[data-callout="#{$callout}"] {
+        --callout-color: #{$color-var};
+      }
+    }
+  }
+}
+
+.page article table {
+  border-collapse: collapse;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--lightgray) 70%, transparent);
+}
+
+.page article table th,
+.page article table td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--lightgray) 60%, transparent);
+}
+
+.page article table tbody tr:nth-child(even) {
+  background-color: var(--table-stripe);
+}
+
+// Explorer and navigation refinements
+.explorer button,
+.explorer .folder-container div > a,
+.explorer .folder-container div > button span {
+  color: var(--secondary);
+}
+
+.explorer .folder-container div > a:hover,
+.explorer .folder-container div > button:hover span {
+  color: var(--tertiary);
+}
+
+button,
+input,
+textarea {
+  font-family: var(--bodyFont);
+}
+
+.search .search-button {
+  background-color: var(--lightgray);
+  color: var(--darkgray);
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--lightgray) 60%, transparent);
+}
+
+.search .search-space {
+  background-color: var(--light);
+  color: var(--darkgray);
+  border-radius: 12px;
+  box-shadow: 0 12px 45px rgba(0, 0, 0, 0.18);
+}
+
+.page article hr {
+  border: none;
+  border-top: 2px solid color-mix(in srgb, var(--lightgray) 65%, transparent);
+  margin: 2rem 0;
+}
+
+.page article ul,
+.page article ol {
+  padding-left: 1.25rem;
+}
+
+.page article li::marker {
+  color: var(--tertiary);
+}
+
+.page article ::selection {
+  background-color: var(--textHighlight);
+}


### PR DESCRIPTION
## Summary
- rebuild the Gruvbox theme with scoped CSS variables for light and dark palettes instead of the prior monolithic stylesheet
- refresh headings, links, code blocks, blockquotes, tables, and callouts to follow Gruvbox colors while keeping Quartz defaults working
- tweak explorer, search, and form styling to share the new palette without impacting functionality
- align the embedded Giscus widget with the Gruvbox palette and eliminate its initial animation
- tighten FlexSearch typings so the build continues to pass under the updated toolchain

## Testing
- npx quartz build
- CI=1 npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d8589990488327807a052b39033330