### PR TITLE
Fix Gruvbox heading colors and selection contrast

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -102,9 +102,12 @@ body {
 
 .page-title,
 .page-title a,
+.article-title,
+.article-title a,
 .page article h1,
 .page article h1 a,
-header h1 {
+header h1,
+header h1 a {
   color: var(--heading-1) !important;
 }
 
@@ -360,6 +363,12 @@ textarea {
   color: var(--tertiary);
 }
 
-.page article ::selection {
+.page article ::selection,
+header ::selection,
+.page-title::selection,
+.page-title a::selection,
+.article-title::selection,
+.article-title a::selection {
   background-color: var(--textHighlight);
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- ensure the page and article titles inherit the Gruvbox red accent
- preserve heading colors when text is highlighted to improve readability

## Testing
- npm run build *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68d87658a5288327910a6c002b514130