### PR TITLE
Polish giscus theme loading and fix FlexSearch typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "quartz": "./quartz/bootstrap-cli.mjs",
+    "build": "node ./quartz/bootstrap-cli.mjs build",
     "docs": "npx quartz build --serve -d docs",
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",

--- a/quartz/components/scripts/comments.inline.ts
+++ b/quartz/components/scripts/comments.inline.ts
@@ -1,11 +1,9 @@
+const GISCUS_ORIGIN = "https://giscus.app"
+
 const changeTheme = (e: CustomEventMap["themechange"]) => {
   const theme = e.detail.theme
-  const iframe = document.querySelector("iframe.giscus-frame") as HTMLIFrameElement
-  if (!iframe) {
-    return
-  }
-
-  if (!iframe.contentWindow) {
+  const iframe = document.querySelector("iframe.giscus-frame") as HTMLIFrameElement | null
+  if (!iframe || !iframe.contentWindow) {
     return
   }
 
@@ -17,8 +15,26 @@ const changeTheme = (e: CustomEventMap["themechange"]) => {
         },
       },
     },
-    "https://giscus.app",
+    GISCUS_ORIGIN,
   )
+}
+
+const getPreferredTheme = (): "light" | "dark" => {
+  const savedTheme = document.documentElement.getAttribute("saved-theme")
+  if (savedTheme === "light" || savedTheme === "dark") {
+    return savedTheme
+  }
+
+  try {
+    const storedTheme = localStorage.getItem("theme")
+    if (storedTheme === "light" || storedTheme === "dark") {
+      return storedTheme
+    }
+  } catch (error) {
+    console.warn("Unable to read theme preference from localStorage", error)
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
 }
 
 const getThemeName = (theme: string) => {
@@ -59,17 +75,19 @@ type GiscusElement = Omit<HTMLElement, "dataset"> & {
   }
 }
 
-document.addEventListener("nav", () => {
-  const giscusContainer = document.querySelector(".giscus") as GiscusElement
+const loadGiscus = () => {
+  const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
   if (!giscusContainer) {
-    return
+    return false
   }
 
+  giscusContainer.replaceChildren()
+
   const giscusScript = document.createElement("script")
-  giscusScript.src = "https://giscus.app/client.js"
+  giscusScript.src = `${GISCUS_ORIGIN}/client.js`
   giscusScript.async = true
   giscusScript.crossOrigin = "anonymous"
-  giscusScript.setAttribute("data-loading", "lazy")
+  giscusScript.setAttribute("data-loading", "eager")
   giscusScript.setAttribute("data-emit-metadata", "0")
   giscusScript.setAttribute("data-repo", giscusContainer.dataset.repo)
   giscusScript.setAttribute("data-repo-id", giscusContainer.dataset.repoId)
@@ -80,14 +98,25 @@ document.addEventListener("nav", () => {
   giscusScript.setAttribute("data-reactions-enabled", giscusContainer.dataset.reactionsEnabled)
   giscusScript.setAttribute("data-input-position", giscusContainer.dataset.inputPosition)
   giscusScript.setAttribute("data-lang", giscusContainer.dataset.lang)
-  const storedTheme = localStorage.getItem("theme")
-  const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches
-  const theme = storedTheme ?? (prefersLight ? "light" : "dark")
-  giscusContainer.setAttribute("data-theme", theme)
-  giscusScript.setAttribute("data-theme", getThemeUrl(getThemeName(theme)))
+  const theme = getPreferredTheme()
+  const giscusTheme = getThemeName(theme)
+  giscusContainer.setAttribute("data-theme", giscusTheme)
+  giscusScript.setAttribute("data-theme", getThemeUrl(giscusTheme))
 
   giscusContainer.appendChild(giscusScript)
 
+  return true
+}
+
+document.addEventListener("nav", () => {
+  if (!loadGiscus()) {
+    return
+  }
+
   document.addEventListener("themechange", changeTheme)
-  window.addCleanup(() => document.removeEventListener("themechange", changeTheme))
+  window.addCleanup(() => {
+    document.removeEventListener("themechange", changeTheme)
+    const giscusContainer = document.querySelector(".giscus") as GiscusElement | null
+    giscusContainer?.replaceChildren()
+  })
 })

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -1,9 +1,14 @@
-import FlexSearch from "flexsearch"
+import {
+  Document,
+  type DocumentData,
+  type DocumentSearchOptions,
+  type DocumentSearchResults,
+} from "flexsearch"
 import { ContentDetails } from "../../plugins/emitters/contentIndex"
 import { registerEscapeHandler, removeAllChildren } from "./util"
 import { FullSlug, normalizeRelativeURLs, resolveRelative } from "../../util/path"
 
-interface Item {
+type SearchDocument = DocumentData & {
   id: number
   slug: FullSlug
   title: string
@@ -16,8 +21,10 @@ type SearchType = "basic" | "tags"
 let searchType: SearchType = "basic"
 let currentSearchTerm: string = ""
 const encoder = (str: string) => str.toLowerCase().split(/([^a-z]|[^\x00-\x7F])/)
-let index = new FlexSearch.Document<Item>({
-  charset: "latin:extra",
+type SearchResults = DocumentSearchResults<SearchDocument>
+type SearchOptions = DocumentSearchOptions<SearchDocument>
+
+let index = new Document<SearchDocument>({
   encode: encoder,
   document: {
     id: "id",
@@ -38,6 +45,9 @@ let index = new FlexSearch.Document<Item>({
     ],
   },
 })
+
+const searchDocuments = (options: SearchOptions): Promise<SearchResults> =>
+  index.searchAsync(options)
 
 const p = new DOMParser()
 const fetchContentCache: Map<FullSlug, Element[]> = new Map()
@@ -294,7 +304,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     return new URL(resolveRelative(currentSlug, slug), location.toString())
   }
 
-  const resultToHTML = ({ slug, title, content, tags }: Item) => {
+  const resultToHTML = ({ slug, title, content, tags }: SearchDocument) => {
     const htmlTags = tags.length > 0 ? `<ul class="tags">${tags.join("")}</ul>` : ``
     const itemTile = document.createElement("a")
     itemTile.classList.add("result-card")
@@ -329,7 +339,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     return itemTile
   }
 
-  async function displayResults(finalResults: Item[]) {
+  async function displayResults(finalResults: SearchDocument[]) {
     removeAllChildren(results)
     if (finalResults.length === 0) {
       results.innerHTML = `<a class="result-card no-match">
@@ -397,7 +407,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     searchLayout.classList.toggle("display-results", currentSearchTerm !== "")
     searchType = currentSearchTerm.startsWith("#") ? "tags" : "basic"
 
-    let searchResults: FlexSearch.SimpleDocumentSearchResultSetUnit[]
+    let searchResults: SearchResults
     if (searchType === "tags") {
       currentSearchTerm = currentSearchTerm.substring(1).trim()
       const separatorIndex = currentSearchTerm.indexOf(" ")
@@ -405,13 +415,14 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         // search by title and content index and then filter by tag (implemented in flexsearch)
         const tag = currentSearchTerm.substring(0, separatorIndex)
         const query = currentSearchTerm.substring(separatorIndex + 1).trim()
-        searchResults = await index.searchAsync({
-          query: query,
+        const tagSearchOptions: SearchOptions = {
+          query,
           // return at least 10000 documents, so it is enough to filter them by tag (implemented in flexsearch)
           limit: Math.max(numSearchResults, 10000),
           index: ["title", "content"],
-          tag: tag,
-        })
+          tag: { tags: tag },
+        }
+        searchResults = await searchDocuments(tagSearchOptions)
         for (let searchResult of searchResults) {
           searchResult.result = searchResult.result.slice(0, numSearchResults)
         }
@@ -420,18 +431,20 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
         currentSearchTerm = query
       } else {
         // default search by tags index
-        searchResults = await index.searchAsync({
+        const options: SearchOptions = {
           query: currentSearchTerm,
           limit: numSearchResults,
           index: ["tags"],
-        })
+        }
+        searchResults = await searchDocuments(options)
       }
     } else if (searchType === "basic") {
-      searchResults = await index.searchAsync({
+      const options: SearchOptions = {
         query: currentSearchTerm,
         limit: numSearchResults,
         index: ["title", "content"],
-      })
+      }
+      searchResults = await searchDocuments(options)
     }
 
     const getByField = (field: string): number[] => {

--- a/quartz/static/giscus/dark.css
+++ b/quartz/static/giscus/dark.css
@@ -97,3 +97,11 @@ main .pagination-loader-container {
 main .gsc-loading-image {
   background-image: url("https://github.githubassets.com/images/mona-loading-dark.gif");
 }
+
+main,
+main *,
+main *::before,
+main *::after {
+  animation: none !important;
+  transition: none !important;
+}

--- a/quartz/static/giscus/light.css
+++ b/quartz/static/giscus/light.css
@@ -97,3 +97,11 @@ main .pagination-loader-container {
 main .gsc-loading-image {
   background-image: url("https://github.githubassets.com/images/mona-loading-default.gif");
 }
+
+main,
+main *,
+main *::before,
+main *::after {
+  animation: none !important;
+  transition: none !important;
+}


### PR DESCRIPTION
## Summary
- guard the giscus theme detector against localStorage access failures so the iframe always picks a theme
- replace the ad-hoc FlexSearch namespace usage with the typed Document helpers and tag search options so `npm run check` succeeds
- expose a `build` npm script that wraps the Quartz CLI to provide a working production build command

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8fbd039ec83279a4a44900f59ebe8