### PR TITLE
Add CPU-safe market AI pipeline and run wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ tsconfig.tsbuildinfo
 private/
 .replit
 replit.nix
+
+# Python cache
+__pycache__/
+*.pyc

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,19 @@
+# Market AI scripts
+
+This folder provides a CPU-safe deep-learning pipeline scaffold for market experiments.
+
+## Quick start
+
+```bash
+# Always CPU-safe via FORCE_CPU=1 default in run.sh
+scripts/run.sh --csv /path/to/ohlcv.csv --epochs 20
+```
+
+## Why this addresses "no GPU found"
+
+`market_ai/device.py` uses the following priority:
+1. `FORCE_CPU=1` -> always run on CPU.
+2. If torch or CUDA is unavailable -> fallback to CPU automatically.
+3. Only use CUDA when available and not forced off.
+
+So the pipeline runs on machines with or without GPU.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package."""

--- a/scripts/market_ai/__init__.py
+++ b/scripts/market_ai/__init__.py
@@ -1,0 +1,1 @@
+"""Market AI scripts package."""

--- a/scripts/market_ai/backtest.py
+++ b/scripts/market_ai/backtest.py
@@ -1,0 +1,19 @@
+"""Simple walk-forward backtest utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def simple_threshold_backtest(df: pd.DataFrame, score_col: str, threshold: float = 0.0) -> dict:
+    """Long if score > threshold else flat."""
+    work = df.copy()
+    work["position"] = (work[score_col] > threshold).astype(float)
+    work["strategy_ret"] = work["position"] * work["target_next_ret"]
+    equity = (1.0 + work["strategy_ret"].fillna(0.0)).cumprod()
+
+    return {
+        "total_return": float(equity.iloc[-1] - 1.0),
+        "avg_daily_ret": float(work["strategy_ret"].mean()),
+        "vol_daily": float(work["strategy_ret"].std()),
+    }

--- a/scripts/market_ai/data_pipeline.py
+++ b/scripts/market_ai/data_pipeline.py
@@ -1,0 +1,46 @@
+"""Data loading and feature generation for market modeling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+
+@dataclass
+class DatasetBundle:
+    train: pd.DataFrame
+    valid: pd.DataFrame
+    test: pd.DataFrame
+
+
+def load_ohlcv_csv(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    expected = {"timestamp", "open", "high", "low", "close", "volume"}
+    missing = expected - set(df.columns)
+    if missing:
+        raise ValueError(f"Missing columns: {sorted(missing)}")
+    df = df.sort_values("timestamp").reset_index(drop=True)
+    return df
+
+
+def add_features(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    out["ret_1"] = out["close"].pct_change()
+    out["ret_5"] = out["close"].pct_change(5)
+    out["vol_10"] = out["ret_1"].rolling(10).std()
+    out["sma_10"] = out["close"].rolling(10).mean()
+    out["sma_30"] = out["close"].rolling(30).mean()
+    out["sma_ratio"] = out["sma_10"] / out["sma_30"]
+    out["target_next_ret"] = out["ret_1"].shift(-1)
+    return out.dropna().reset_index(drop=True)
+
+
+def time_split(df: pd.DataFrame, train=0.7, valid=0.15) -> DatasetBundle:
+    n = len(df)
+    a = int(n * train)
+    b = int(n * (train + valid))
+    return DatasetBundle(
+        train=df.iloc[:a].copy(), valid=df.iloc[a:b].copy(), test=df.iloc[b:].copy()
+    )

--- a/scripts/market_ai/device.py
+++ b/scripts/market_ai/device.py
@@ -1,0 +1,37 @@
+"""Device selection helpers with guaranteed CPU fallback."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeviceConfig:
+    torch_device: str
+    reason: str
+
+
+def select_device(prefer_gpu: bool = True) -> DeviceConfig:
+    """Return a safe torch device.
+
+    Behavior:
+    - FORCE_CPU=1 forces CPU regardless of GPU availability.
+    - If torch is not installed, default to CPU.
+    - If torch is installed but CUDA is unavailable, default to CPU.
+    """
+    force_cpu = os.getenv("FORCE_CPU", "0") == "1"
+    if force_cpu:
+        return DeviceConfig("cpu", "FORCE_CPU=1")
+
+    if not prefer_gpu:
+        return DeviceConfig("cpu", "prefer_gpu=False")
+
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return DeviceConfig("cuda", "torch.cuda.is_available=True")
+        return DeviceConfig("cpu", "CUDA unavailable")
+    except Exception:
+        return DeviceConfig("cpu", "torch unavailable")

--- a/scripts/market_ai/models.py
+++ b/scripts/market_ai/models.py
@@ -1,0 +1,35 @@
+"""Model builders with CPU-safe defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .device import DeviceConfig
+
+
+@dataclass
+class ModelConfig:
+    input_dim: int
+    hidden_dim: int = 64
+    num_layers: int = 2
+    dropout: float = 0.1
+
+
+def build_torch_mlp(cfg: ModelConfig, device: DeviceConfig):
+    try:
+        import torch.nn as nn
+
+        layers = []
+        in_dim = cfg.input_dim
+        for _ in range(cfg.num_layers):
+            layers.append(nn.Linear(in_dim, cfg.hidden_dim))
+            layers.append(nn.ReLU())
+            layers.append(nn.Dropout(cfg.dropout))
+            in_dim = cfg.hidden_dim
+        layers.append(nn.Linear(in_dim, 1))
+        model = nn.Sequential(*layers)
+        return model.to(device.torch_device)
+    except Exception as exc:
+        raise RuntimeError(
+            "PyTorch model initialization failed. Ensure torch is installed."
+        ) from exc

--- a/scripts/market_ai/orchestrator.py
+++ b/scripts/market_ai/orchestrator.py
@@ -1,0 +1,38 @@
+"""End-to-end orchestration script for market ML experiments.
+
+This script is intentionally modular so teams can connect it to:
+- broker APIs
+- feature stores
+- model registries
+- scheduling/orchestration tools
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from .data_pipeline import add_features, load_ohlcv_csv, time_split
+from .train import train_mlp
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run CPU-safe market ML pipeline")
+    parser.add_argument("--csv", required=True, help="Path to OHLCV csv")
+    parser.add_argument("--epochs", type=int, default=10)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    raw = load_ohlcv_csv(args.csv)
+    feat = add_features(raw)
+    split = time_split(feat)
+
+    result = train_mlp(split.train, split.valid, epochs=args.epochs)
+    print("Training complete")
+    print(f"Device used: {result.device}")
+    print(f"Best valid loss: {result.best_valid_loss:.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/market_ai/train.py
+++ b/scripts/market_ai/train.py
@@ -1,0 +1,57 @@
+"""Training loop with graceful CPU fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .device import select_device
+from .models import ModelConfig, build_torch_mlp
+
+
+@dataclass
+class TrainResult:
+    device: str
+    best_valid_loss: float
+
+
+def _to_xy(df: pd.DataFrame):
+    feats = [c for c in df.columns if c not in {"timestamp", "target_next_ret"}]
+    x = df[feats].to_numpy(dtype=np.float32)
+    y = df["target_next_ret"].to_numpy(dtype=np.float32).reshape(-1, 1)
+    return x, y, len(feats)
+
+
+def train_mlp(train_df: pd.DataFrame, valid_df: pd.DataFrame, epochs: int = 10) -> TrainResult:
+    import torch
+
+    device = select_device(prefer_gpu=True)
+    x_train, y_train, input_dim = _to_xy(train_df)
+    x_valid, y_valid, _ = _to_xy(valid_df)
+
+    model = build_torch_mlp(ModelConfig(input_dim=input_dim), device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = torch.nn.MSELoss()
+
+    tx = torch.from_numpy(x_train).to(device.torch_device)
+    ty = torch.from_numpy(y_train).to(device.torch_device)
+    vx = torch.from_numpy(x_valid).to(device.torch_device)
+    vy = torch.from_numpy(y_valid).to(device.torch_device)
+
+    best = float("inf")
+    for _ in range(epochs):
+        model.train()
+        optimizer.zero_grad()
+        pred = model(tx)
+        loss = loss_fn(pred, ty)
+        loss.backward()
+        optimizer.step()
+
+        model.eval()
+        with torch.no_grad():
+            vloss = loss_fn(model(vx), vy).item()
+            best = min(best, vloss)
+
+    return TrainResult(device=device.torch_device, best_valid_loss=best)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CPU-safe default. Override with FORCE_CPU=0 if you explicitly want GPU auto-detect.
+: "${FORCE_CPU:=1}"
+
+python3 -m scripts.market_ai.orchestrator "$@"


### PR DESCRIPTION
### Motivation
- Ensure the project can run the research pipeline on machines without a GPU by providing a CPU-first entrypoint. 
- Provide a small, modular scaffold for market ML experiments that teams can connect to brokers, feature stores, and orchestration systems. 
- Prevent accidental failures when `torch` or CUDA are unavailable by falling back to CPU deterministically. 

### Description
- Added a CPU-first entrypoint `scripts/run.sh` that defaults to `FORCE_CPU=1` and launches the orchestrator via `python3 -m scripts.market_ai.orchestrator`.
- Added `scripts/market_ai/device.py` with `select_device` that picks `cpu` when `FORCE_CPU=1`, when `torch` is missing, or when CUDA is unavailable, and otherwise returns `cuda` when available.
- Added modular pipeline code under `scripts/market_ai/` including `data_pipeline.py` (CSV loader, feature generation, time splits), `models.py` (CPU-safe MLP builder), `train.py` (training loop using `select_device`), and `backtest.py` (simple threshold backtest utilities).
- Added usage docs at `scripts/README.md` and added Python cache ignores to `.gitignore` to avoid committing `__pycache__`/`.pyc` artifacts.

### Testing
- Verified Python syntax and importability with `python3 -m py_compile` for the added Python modules, which succeeded.
- Verified the shell wrapper with `bash -n scripts/run.sh`, which succeeded.
- No runtime GPU-dependent tests were executed; the code is structured to operate on CPU by default and will use CUDA only when `FORCE_CPU=0` and CUDA is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7823b86c8327bc0641deed6c07b6)